### PR TITLE
Add favicon metadata links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Adventure Log Dashboard</title>
+<link rel="icon" type="image/svg+xml" href="favicon.svg"/>
+<link rel="icon" type="image/png" sizes="96x96" href="favicon-96x96.png"/>
+<link rel="shortcut icon" href="favicon.ico"/>
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png"/>
+<link rel="manifest" href="site.webmanifest"/>
 <style>
 :root{
   --bg:#f6f8fb; --surface:#fff; --ink:#0f172a; --muted:#64748b; --primary:#1a73e8; --border:#e5eaf3;


### PR DESCRIPTION
## Summary
- add favicon and manifest link tags to the dashboard HTML head so browsers can load the favicon assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a46bdda483219a2ac594e6983c71