### PR TITLE
Clean up consumables modal integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,244 +175,6 @@ html,body,.grid,.grid .col,.card-bd{overflow-anchor:none}
 
 <script src="data.js"></script>
 <script>
-/* ---------- data boot ---------- */
-const DATA = window.DATA || null;
-if (!DATA || !DATA.characters) {
-  const e = document.getElementById('empty');
-  e.style.display='block'; e.innerHTML='Could not load <code>data.js</code>.'; throw new Error('DATA missing');
-}
-
-/* ---------- DOM handles ---------- */
-const charSel  = document.getElementById('charSel');
-const yearEl   = document.getElementById('year');
-const qEl      = document.getElementById('q');
-const grid     = document.getElementById('grid');
-const emptyEl  = document.getElementById('empty');
-const statsEl  = document.getElementById('stats');
-const titleEl  = document.getElementById('charTitle');
-const metaEl   = document.getElementById('charMeta');
-const badgesEl = document.getElementById('charBadges');
-
-/* ---------- character selector (no session counts) ---------- */
-Object.entries(DATA.characters).forEach(([key,obj])=>{
-  const opt=document.createElement('option');
-  const disp=(obj.display_name&&obj.display_name!==key)?(obj.display_name+' ('+obj.sheet+')'):obj.sheet;
-  opt.value=key; opt.textContent=disp; charSel.appendChild(opt);
-});
-
-/* ---------- utils ---------- */
-function fmtDate(iso){ if(!iso)return'—'; const d=new Date(iso); if(isNaN(d))return String(iso); return d.toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'}); }
-function pill(label){ const s=document.createElement('span'); s.className='pill'; s.textContent=label; return s; }
-function sanitizeTitle(title){
-  if(!title) return '';
-  return String(title).replace(/\bdown\s*time\s*activity\b/gi,'').replace(/\s{2,}/g,' ').replace(/^[\s:,.–—-]+|[\s:,.–—-]+$/g,'').trim();
-}
-function listBox(items){
-  const wrap=document.createElement('div'); wrap.className='scrollbox';
-  if(!items||!items.length){ wrap.innerHTML='<div class="muted">—</div>'; return wrap; }
-  items.forEach(name=>{ const row=document.createElement('div'); row.className='item'; row.textContent='• '+String(name); wrap.appendChild(row); });
-  return wrap;
-}
-function getMostRecentCharacter(){
-  let latestKey=null, latestDate=0;
-  for (const [key,obj] of Object.entries(DATA.characters)){
-    if(!obj.adventures||!obj.adventures.length) continue;
-    const maxDate=Math.max(...obj.adventures.map(a=>{ const t=new Date(a.date).getTime(); return isNaN(t)?0:t; }));
-    if(maxDate>latestDate){ latestDate=maxDate; latestKey=key; }
-  }
-  return latestKey || Object.keys(DATA.characters)[0];
-}
-function isActivityEntry(a){ return a && a.kind && a.kind!=='adventure'; }
-function netVals(a){ return { gp:(+a.gp_plus||0)-(+a.gp_minus||0), dtd:(+a.dtd_plus||0)-(+a.dtd_minus||0) }; }
-function fmtSigned(n){ if(!n) return '0'; return (n>0?'+':'')+(Math.round(n*100)/100); }
-
-/* ---------- smooth expand/collapse ---------- */
-function isAnimating(card){ return card.dataset.anim==='1'; }
-function setAnimating(card,on){ if(on) card.dataset.anim='1'; else delete card.dataset.anim; }
-function afterTransition(el,prop,ms,cb){ let done=false; const onEnd=e=>{ if(e.propertyName!==prop||done)return; done=true; el.removeEventListener('transitionend',onEnd); cb(); }; el.addEventListener('transitionend',onEnd); setTimeout(()=>{ if(done)return; done=true; el.removeEventListener('transitionend',onEnd); cb(); },ms); }
-function expandCard(card){ if(isAnimating(card))return; const bd=card.querySelector('.card-bd'); if(!bd)return; setAnimating(card,true); bd.style.height=bd.offsetHeight+'px'; bd.style.opacity='0'; card.classList.add('open'); requestAnimationFrame(()=>{ bd.style.height=bd.scrollHeight+'px'; bd.style.opacity='1'; }); afterTransition(bd,'height',450,()=>{ bd.style.height='auto'; setAnimating(card,false); columnizeGrid('relayout'); }); }
-function collapseCard(card){ if(isAnimating(card))return; const bd=card.querySelector('.card-bd'); if(!bd)return; setAnimating(card,true); const h=bd.offsetHeight||bd.scrollHeight; bd.style.height=h+'px'; bd.style.opacity='1'; void bd.offsetHeight; requestAnimationFrame(()=>{ bd.style.height='0px'; bd.style.opacity='0'; }); afterTransition(bd,'height',450,()=>{ card.classList.remove('open'); setAnimating(card,false); columnizeGrid('relayout'); }); }
-function toggleCard(card){ card.classList.contains('open')?collapseCard(card):expandCard(card); }
-
-/* ---------- inventory helpers (permanent & consumables) ---------- */
-function normItemName(s){ return (s||'').trim(); }
-function parseAcquisitionName(s){ const t=String(s||'').trim(); const m=t.match(/^\((.*)\)$/); return m?{name:m[1].trim(),acquired:false}:{name:t,acquired:true}; }
-function looksLikeLossEntry(entry){ const t=((entry.title||'')+' '+(entry.notes||'')).toLowerCase(); return /trade|traded|sold|gave|gifted|lost|relinquish|transfer/.test(t); }
-
-/* Permanent inventory from log */
-function buildPermanentInventory(charKey){
-  const ch=DATA.characters[charKey]; if(!ch||!ch.adventures) return [];
-  const sorted=[...ch.adventures].sort((a,b)=>new Date(a.date||'1900-01-01')-new Date(b.date||'1900-01-01'));
-  const kept=[];
-  function add(name){ name=normItemName(name); if(!name) return; if(!kept.some(n=>n.toLowerCase()===name.toLowerCase())) kept.push(name); }
-  function remove(name){ name=normItemName(name); const i=kept.findIndex(n=>n.toLowerCase()===name.toLowerCase()); if(i>=0) kept.splice(i,1); }
-  sorted.forEach(e=>{
-    const items=e.perm_items||[];
-    const isLoss=(e.kind&&e.kind!=='adventure')?looksLikeLossEntry(e):false;
-    if(isLoss){
-      if(items.length) items.forEach(raw=>remove(raw.replace(/^\(|\)$/g,'')));
-      else if(e.notes){ kept.slice().forEach(ex=>{ if(new RegExp('\\b'+ex.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')+'\\b','i').test(e.notes)) remove(ex); }); }
-      return;
-    }
-    items.forEach(raw=>{ const {name,acquired}=parseAcquisitionName(raw); if(acquired) add(name); });
-  });
-  return kept;
-}
-function currentLevelFor(charKey){
-  const ch=DATA.characters[charKey]; const lvl=1+Math.floor((ch.adventures||[]).reduce((s,a)=>s+(+a.level_plus||0),0)); return Math.max(1,lvl);
-}
-function activeSlotsFor(level){ if(level<=4)return 1; if(level<=10)return 3; if(level<=16)return 6; return 10; }
-function activeKey(k){ return 'ACTIVE_INV__'+k; }
-function attuneKey(k){ return 'ATTUNED__'+k; }
-function loadActive(k){ try{return JSON.parse(localStorage.getItem(activeKey(k))||'[]')}catch(_){return[]} }
-function saveActive(k,a){ localStorage.setItem(activeKey(k),JSON.stringify(a||[])) }
-function loadAttuned(k){ try{return JSON.parse(localStorage.getItem(attuneKey(k))||'[]')}catch(_){return[]} }
-function saveAttuned(k,a){ localStorage.setItem(attuneKey(k),JSON.stringify(a||[])) }
-
-/* Consumables inventory from log (+ manual uses) */
-function parseConsumableName(s){ const t=String(s||'').trim(); const m=t.match(/^\((.*)\)$/); return m?{name:m[1].trim(),acquired:false}:{name:t,acquired:true}; }
-function consumedKey(k){ return 'CONSUMED__'+k; }
-function loadConsumed(k){ try{ return JSON.parse(localStorage.getItem(consumedKey(k))||'{}'); }catch(_){ return {}; } }
-function saveConsumed(k,obj){ localStorage.setItem(consumedKey(k), JSON.stringify(obj||{})); }
-function buildConsumableInventory(charKey){
-  const ch=DATA.characters[charKey]; if (!ch || !ch.adventures) return new Map();
-  const sorted=[...ch.adventures].sort((a,b)=>new Date(a.date||'1900-01-01')-new Date(b.date||'1900-01-01'));
-  const counts=new Map();
-  const add=(n,k=1)=>{ n=n.trim(); if(!n) return; counts.set(n,(counts.get(n)||0)+k); };
-  const sub=(n,k=1)=>{ n=n.trim(); if(!n) return; const cur=(counts.get(n)||0)-k; counts.set(n,Math.max(0,cur)); if(counts.get(n)===0) counts.delete(n); };
-  sorted.forEach(e=>{
-    const items=e.consumable_items||[];
-    const isLoss=(e.kind&&e.kind!=='adventure')?looksLikeLossEntry(e):false;
-    if(isLoss){
-      if(items.length) items.forEach(raw=>sub(raw.replace(/^\(|\)$/g,'')));
-      else if(e.notes){ [...counts.keys()].forEach(name=>{ if(new RegExp('\\b'+name.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')+'\\b','i').test(e.notes)) sub(name); }); }
-      return;
-    }
-    items.forEach(raw=>{ const {name,acquired}=parseConsumableName(raw); if(acquired) add(name); });
-  });
-  const used=loadConsumed(charKey);
-  Object.entries(used).forEach(([n,c])=>sub(n,c||0));
-  return counts;
-}
-
-/* ---------- Inventory modals ---------- */
-const invModal=document.getElementById('invModal');
-const invTitle=document.getElementById('invTitle');
-const invMeta=document.getElementById('invMeta');
-const invList=document.getElementById('invList');
-const invSummary=document.getElementById('invSummary');
-document.getElementById('invClose').addEventListener('click',()=>invModal.classList.remove('open'));
-invModal.addEventListener('click',(e)=>{ if(e.target===invModal) invModal.classList.remove('open'); });
-
-function openInventoryModal(charKey){
-  const ch=DATA.characters[charKey];
-  const level=currentLevelFor(charKey);
-  const cap=activeSlotsFor(level);
-  const kept=buildPermanentInventory(charKey);
-  let active=loadActive(charKey).filter(n=>kept.some(k=>k.toLowerCase()===n.toLowerCase()));
-  let attuned=loadAttuned(charKey).filter(n=>kept.some(k=>k.toLowerCase()===n.toLowerCase()));
-  if(active.length>cap) active=active.slice(0,cap);
-  if(attuned.length>3) attuned=attuned.slice(0,3);
-
-  invTitle.textContent=(ch.display_name||ch.sheet||'Character')+' — Permanent Items';
-  invMeta.textContent=`Level ${level} • Active slots: ${cap} • Attunement max: 3`;
-
-  const activeSet=new Set(active.map(a=>a.toLowerCase()));
-  const attunedSet=new Set(attuned.map(a=>a.toLowerCase()));
-  const rest=kept.filter(n=>!activeSet.has(n.toLowerCase())).sort((a,b)=>a.localeCompare(b));
-  const ordered=active.concat(rest);
-
-  invList.innerHTML='';
-  ordered.forEach(name=>{
-    const isActive=activeSet.has(name.toLowerCase());
-    const row=document.createElement('div');
-    row.className='inv-row'+(isActive?' active':'');
-    row.dataset.name=name;
-
-    const nameDiv=document.createElement('div');
-    nameDiv.className='inv-name';
-    nameDiv.textContent=name;
-
-    const rightDiv=document.createElement('div');
-    if(isActive){
-      const pill=document.createElement('span');
-      pill.className='attune-pill'+(attunedSet.has(name.toLowerCase())?' on':'');
-      pill.textContent=attunedSet.has(name.toLowerCase())?'Attuned':'Attune';
-      pill.title='Toggle.card.activity .chips{display:flex;flex:0 0 auto;align-items:center;gap:6px;margin:0;white-space:nowrap}
-.card.activity .pill{height:22px;line-height:22px;padding:0 8px;max-width:160px;overflow:hidden;text-overflow:ellipsis}
-.pill.muted{background:#eef1f6;color:#475569;border-color:#dce2ee}
-
-/* Inventory modal */
-.modal{position:fixed;inset:0;display:none;place-items:center;background:rgba(15,23,42,.4);z-index:50}
-.modal.open{display:grid}
-.modal-card{width:min(92vw,800px);max-height:80vh;background:#fff;border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow2);display:flex;flex-direction:column;overflow:hidden}
-.modal-hd{padding:14px 16px;border-bottom:1px solid var(--border);font-weight:700;display:flex;align-items:center;justify-content:space-between;gap:8px}
-.modal-body{padding:12px 16px;overflow:auto}
-.modal-actions{padding:12px 16px;border-top:1px solid var(--border);display:flex;justify-content:flex-end;gap:8px}
-.inv-meta{color:var(--muted);font-size:12px}
-.inv-list{display:flex;flex-direction:column;gap:6px}
-
-/* Alternating rows + active highlight */
-.inv-row{display:grid;grid-template-columns:1fr auto;align-items:center;padding:6px 10px;border-radius:8px;cursor:pointer;transition:background .2s}
-.inv-row:nth-child(odd){background:#fafbfc}
-.inv-row:nth-child(even){background:#f2f5f8}
-.inv-row.active{background:#e8f0ff;font-weight:600}
-
-/* Attunement pill (only for active rows) */
-.attune-pill{display:inline-block;border:1px solid #cfe0ff;background:#eef4ff;color:#1a73e8;border-radius:999px;padding:2px 8px;font-size:11px;user-select:none;cursor:pointer;transition:background .2s,color .2s}
-.attune-pill.on{background:#1a73e8;color:#fff}
-
-/* Reduce scroll anchoring jumps */
-html,body,.grid,.grid .col,.card-bd{overflow-anchor:none}
-</style>
-</head>
-<body>
-<div class="container">
-  <section class="header">
-    <div class="row">
-      <div class="avatar" aria-hidden="true"></div>
-      <div>
-        <h1 id="charTitle">Adventure Log</h1>
-        <div class="muted" id="charMeta">Select a sheet/character.</div>
-        <div id="charBadges" style="margin-top:6px;display:flex;gap:6px;flex-wrap:wrap;"></div>
-      </div>
-    </div>
-    <div class="toolbar">
-      <select id="charSel" class="select"></select>
-      <div class="search">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="2"/></svg>
-        <input id="q" placeholder="Search adventures (name, code, notes, DM)"/>
-      </div>
-      <select id="year" class="select"><option value="">All years</option></select>
-      <button id="expandAll" class="btn">Expand All</button>
-      <button id="collapseAll" class="btn">Collapse All</button>
-      <button id="downloadJson" class="btn primary">Download JSON</button>
-    </div>
-    <div class="stats" id="stats" style="margin-top:10px;"></div>
-  </section>
-  <section id="grid" class="grid cols"></section>
-  <div id="empty" class="empty" style="display:none;">No adventures match your filters.</div>
-</div>
-
-<!-- Inventory Modal (placed BEFORE script so IDs exist when JS runs) -->
-<div id="invModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="invTitle">
-  <div class="modal-card">
-    <div class="modal-hd">
-      <div id="invTitle">Permanent Magic Items</div>
-      <div class="inv-meta" id="invMeta"></div>
-    </div>
-    <div class="modal-body">
-      <div id="invSummary" class="inv-meta" style="margin-bottom:8px;"></div>
-      <div id="invList" class="inv-list"></div>
-    </div>
-    <div class="modal-actions">
-      <button class="btn" id="invClose">Close</button>
-    </div>
-  </div>
-</div>
-
-<script src="data.js"></script>
-<script>
 /* --- data boot --- */
 const DATA = window.DATA || null;
 if (!DATA || !DATA.characters) {
@@ -505,14 +267,46 @@ function saveActive(k,a){ localStorage.setItem(activeKey(k),JSON.stringify(a||[]
 function loadAttuned(k){ try{return JSON.parse(localStorage.getItem(attuneKey(k))||'[]')}catch(_){return[]} }
 function saveAttuned(k,a){ localStorage.setItem(attuneKey(k),JSON.stringify(a||[])) }
 
+function parseConsumableName(s){ const t=String(s||'').trim(); const m=t.match(/^\((.*)\)$/); return m?{name:m[1].trim(),acquired:false}:{name:t,acquired:true}; }
+function consumedKey(k){ return 'CONSUMED__'+k; }
+function loadConsumed(k){ try{ return JSON.parse(localStorage.getItem(consumedKey(k))||'{}'); }catch(_){ return {}; } }
+function saveConsumed(k,obj){ localStorage.setItem(consumedKey(k), JSON.stringify(obj||{})); }
+function buildConsumableInventory(charKey){
+  const ch=DATA.characters[charKey]; if (!ch || !ch.adventures) return new Map();
+  const sorted=[...ch.adventures].sort((a,b)=>new Date(a.date||'1900-01-01')-new Date(b.date||'1900-01-01'));
+  const counts=new Map();
+  const add=(n,k=1)=>{ n=n.trim(); if(!n) return; counts.set(n,(counts.get(n)||0)+k); };
+  const sub=(n,k=1)=>{ n=n.trim(); if(!n) return; const cur=(counts.get(n)||0)-k; counts.set(n,Math.max(0,cur)); if(counts.get(n)===0) counts.delete(n); };
+  sorted.forEach(e=>{
+    const items=e.consumable_items||[];
+    const isLoss=(e.kind&&e.kind!=='adventure')?looksLikeLossEntry(e):false;
+    if(isLoss){
+      if(items.length) items.forEach(raw=>sub(raw.replace(/^\(|\)$/g,'')));
+      else if(e.notes){ [...counts.keys()].forEach(name=>{ if(new RegExp('\\b'+name.replace(/[.*+?^${}()|[\\]\\\\]/g,'\\$&')+'\\b','i').test(e.notes)) sub(name); }); }
+      return;
+    }
+    items.forEach(raw=>{ const {name,acquired}=parseConsumableName(raw); if(acquired) add(name); });
+  });
+  const used=loadConsumed(charKey);
+  Object.entries(used).forEach(([n,c])=>sub(n,c||0));
+  return counts;
+}
+
 /* --- inventory modal UI --- */
 const invModal=document.getElementById('invModal');
 const invTitle=document.getElementById('invTitle');
 const invMeta=document.getElementById('invMeta');
 const invList=document.getElementById('invList');
 const invSummary=document.getElementById('invSummary');
+const consModal=document.getElementById('consModal');
+const consTitle=document.getElementById('consTitle');
+const consMeta=document.getElementById('consMeta');
+const consList=document.getElementById('consList');
+const consSummary=document.getElementById('consSummary');
 document.getElementById('invClose').addEventListener('click',()=>invModal.classList.remove('open'));
+document.getElementById('consClose').addEventListener('click',()=>consModal.classList.remove('open'));
 invModal.addEventListener('click',(e)=>{ if(e.target===invModal) invModal.classList.remove('open'); });
+consModal.addEventListener('click',(e)=>{ if(e.target===consModal) consModal.classList.remove('open'); });
 
 function openInventoryModal(charKey){
   const ch=DATA.characters[charKey];
@@ -596,6 +390,113 @@ function openInventoryModal(charKey){
   invModal.classList.add('open');
 }
 
+function openConsumableModal(charKey){
+  const ch=DATA.characters[charKey];
+  const counts=buildConsumableInventory(charKey);
+  const consumed=loadConsumed(charKey);
+  const names=new Set([...counts.keys(), ...Object.keys(consumed||{})]);
+  const ordered=[...names].sort((a,b)=>a.localeCompare(b,undefined,{sensitivity:'base'}));
+
+  consTitle.textContent=(ch.display_name||ch.sheet||'Character')+' — Consumables';
+  consMeta.textContent='Use the controls below to track consumable usage (stored locally).';
+  consList.innerHTML='';
+
+  const states=[];
+  function updateSummary(){
+    if(!states.length){
+      consSummary.textContent='No consumables tracked yet.';
+      return;
+    }
+    const remainingTotal=states.reduce((sum,state)=>sum+state.remaining,0);
+    const stocked=states.filter(state=>state.remaining>0).length;
+    const tracked=states.length;
+    const itemLabel=tracked===1?'item':'items';
+    consSummary.textContent=`Remaining uses: ${remainingTotal} • ${stocked}/${tracked} ${itemLabel} with stock`;
+  }
+
+  ordered.forEach(name=>{
+    const remaining=counts.get(name)||0;
+    const used=Math.max(0, consumed[name]||0);
+    const total=remaining+used;
+    if(total<=0) return;
+
+    const state={name,remaining,used,total};
+    states.push(state);
+
+    const row=document.createElement('div');
+    row.className='inv-row';
+
+    const nameDiv=document.createElement('div');
+    nameDiv.className='inv-name';
+    nameDiv.textContent=name;
+
+    const qtyDiv=document.createElement('div');
+    qtyDiv.className='qty';
+
+    const minus=document.createElement('button');
+    minus.type='button';
+    minus.className='qty-btn';
+    minus.textContent='−';
+
+    const pill=document.createElement('span');
+    pill.className='qty-pill';
+
+    const useBtn=document.createElement('button');
+    useBtn.type='button';
+    useBtn.className='qty-btn use';
+    useBtn.textContent='Use';
+
+    function sync(){
+      pill.textContent=state.total?`${state.remaining}/${state.total}`:String(state.remaining);
+      minus.disabled=state.used<=0;
+      useBtn.disabled=state.remaining<=0;
+    }
+
+    minus.addEventListener('click',(ev)=>{
+      ev.stopPropagation();
+      if(state.used<=0) return;
+      state.used-=1;
+      state.remaining+=1;
+      if(state.used<=0) delete consumed[name];
+      else consumed[name]=state.used;
+      saveConsumed(charKey,consumed);
+      sync();
+      updateSummary();
+    });
+
+    useBtn.addEventListener('click',(ev)=>{
+      ev.stopPropagation();
+      if(state.remaining<=0) return;
+      state.remaining-=1;
+      state.used+=1;
+      consumed[name]=state.used;
+      saveConsumed(charKey,consumed);
+      sync();
+      updateSummary();
+    });
+
+    qtyDiv.appendChild(minus);
+    qtyDiv.appendChild(pill);
+    qtyDiv.appendChild(useBtn);
+
+    row.appendChild(nameDiv);
+    row.appendChild(qtyDiv);
+
+    consList.appendChild(row);
+    sync();
+  });
+
+  if(!states.length){
+    const empty=document.createElement('div');
+    empty.className='muted';
+    empty.textContent='No consumables tracked yet.';
+    consList.appendChild(empty);
+  }
+
+  updateSummary();
+  consModal.classList.add('open');
+}
+
 /* --- cards --- */
 function makeCard(a,idx){
   const act=isActivityEntry(a); const {gp,dtd}=netVals(a);
@@ -651,6 +552,8 @@ function renderStats(key){
   rows.forEach(([label,val,name])=>{ const el=document.createElement('div'); el.className='stat'; el.dataset.key=name; el.innerHTML='<div class="k">'+val+'</div><div class="v">'+label+'</div>'; statsEl.appendChild(el); });
   const permTile=statsEl.querySelector('[data-key="perm_items"]');
   if(permTile){ permTile.style.cursor='pointer'; permTile.title='Click to view cumulative permanent inventory'; permTile.addEventListener('click',()=>openInventoryModal(charSel.value)); }
+  const consTile=statsEl.querySelector('[data-key="consumables"]');
+  if(consTile){ consTile.style.cursor='pointer'; consTile.title='Click to view consumables summary'; consTile.addEventListener('click',()=>openConsumableModal(charSel.value)); }
 }
 function setHeader(key){
   const obj=DATA.characters[key];


### PR DESCRIPTION
## Summary
- remove the stale duplicated script block and align the consumables modal with the latest page structure
- retain the consumable inventory modal wiring with quantity controls and live summary updates
- keep the stats tile interactions pointing to the consumables modal in the refreshed script

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8a3c5ff7483219433c6309638b7ec