### PR TITLE
Adjust stat layout for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@ h1{margin:0;font-size:18px;font-weight:700}
 /* Stats */
 .stats{display:flex;gap:10px;flex-wrap:wrap}
 .stat{background:#f9fafb;border:1px solid var(--border);border-radius:12px;padding:12px;min-width:100px;flex:1 1 140px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;text-align:center}
+@media (max-width:480px){
+  .stats{justify-content:space-between}
+  .stat{padding:10px;flex:1 1 calc((100% - 20px)/3);max-width:calc((100% - 20px)/3);min-width:0}
+}
 .stat .k{font-weight:700;font-size:18px}
 .stat .v{color:var(--muted);font-size:12px}
 


### PR DESCRIPTION
## Summary
- add a mobile breakpoint that narrows stat cards so three fit in a row on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c642a23c83218b42546929b7ba01