### PR TITLE
Reorder level and session stats tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1233,10 +1233,10 @@ function renderStats(key){
   const levelUps=Number(s.level_ups||0);
   const currentLevel=(Number.isFinite(levelUps)?Math.round(levelUps):0)+1;
   const rows=[
-    ['Sessions',s.sessions||0,'sessions'],
+    ['Level',currentLevel,'level'],
     ['Gold Pieces',Math.round(((s.net_gp||0)*100))/100,'net_gp'],
     ['Downtime Days',Math.round(((s.net_dtd||0)*100))/100,'net_dtd'],
-    ['Level',currentLevel,'level'],
+    ['Sessions',s.sessions||0,'sessions'],
     ['Magic Items',s.perm_count||0,'perm_items'],
     ['Consumables',s.cons_count||0,'consumables']
   ];


### PR DESCRIPTION
## Summary
- swap the display order of the level and sessions stat tiles so level now appears first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d8ff116483219bdd5a5f5ff6a23b