### PR TITLE
Adjust header alignment and download icon styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 html,body{margin:0;padding:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;color:var(--ink);background:var(--bg);scrollbar-gutter:stable}
 .container{max-width:1200px;margin:28px auto 80px;padding:0 20px 120px}
 .header{position:relative;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:16px;box-shadow:var(--shadow1);padding-right:76px}
-.row{display:flex;gap:12px;align-items:flex-start;flex-wrap:wrap}
+.row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
 .avatar{width:56px;height:56px;border-radius:14px;background:linear-gradient(135deg,var(--primary),#34a853);box-shadow:var(--shadow1)}
 h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01em}
 .header-main{display:flex;flex-direction:column;gap:6px;min-width:0;flex:1 1 auto}
@@ -60,13 +60,12 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .icon-btn.primary{background:var(--primary);color:#fff;border-color:var(--primary)}
 .icon-btn.primary:hover{box-shadow:var(--shadow2)}
 .icon-btn[disabled]{opacity:.5;cursor:not-allowed;box-shadow:none;background:#f1f5f9;color:#94a3b8}
-.download-btn{position:absolute;top:16px;right:16px;width:40px;height:40px;border-radius:12px;box-shadow:var(--shadow1);color:var(--muted);background:#fff}
-.download-btn svg{width:18px;height:18px}
-.download-btn::after{content:"";position:absolute;top:8px;right:8px;width:8px;height:8px;border-radius:50%;background:var(--primary);opacity:0;transform:scale(.6);transition:opacity var(--dur) var(--ease),transform var(--dur) var(--ease)}
-.download-btn:hover{box-shadow:var(--shadow2)}
-.download-btn.dirty{color:#fff;background:var(--primary);border-color:var(--primary)}
-.download-btn.dirty:hover{background:var(--primary);color:#fff}
-.download-btn.dirty::after{opacity:1;transform:scale(1)}
+.download-btn{position:absolute;top:16px;right:16px;width:auto;height:auto;padding:0;border:none;border-radius:0;background:transparent;box-shadow:none;color:var(--primary)}
+.download-btn svg{width:20px;height:20px}
+.download-btn::after{content:none}
+.download-btn:hover{color:#1257b3}
+.download-btn.dirty{color:#0b3f88;background:transparent}
+.download-btn.dirty:hover{color:#0a3572}
 .download-btn:focus-visible{outline:2px solid rgba(26,115,232,.35);outline-offset:2px}
 
 /* Stats */


### PR DESCRIPTION
## Summary
- align the character header row so the name stays alongside the avatar
- restyle the download action to display only the blue icon without circular chrome

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9eeb274c08321a9c36e1bb07110bf