### PR TITLE
Refine stat box layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   --bg:#f6f8fb; --surface:#fff; --ink:#0f172a; --muted:#64748b; --primary:#1a73e8; --border:#e5eaf3;
   --radius:16px; --shadow1:0 2px 10px rgba(16,24,40,.06); --shadow2:0 20px 40px rgba(16,24,40,.12);
   --dur:220ms; --ease:cubic-bezier(.2,.8,.2,1); --gap:14px; --min-card:320px;
+  --stat-min:170px; --stat-max:240px; --stat-gap:12px;
   --danger:#dc2626;
 }
 *{box-sizing:border-box}
@@ -69,17 +70,27 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .download-btn:focus-visible{outline:2px solid rgba(26,115,232,.35);outline-offset:2px}
 
 /* Stats */
-.stats{display:flex;flex-wrap:wrap;gap:10px}
-.stat{background:#f9fafb;border:1px solid var(--border);border-radius:12px;padding:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;text-align:center;min-width:140px;flex:1 1 140px}
+.stats{display:flex;flex-wrap:wrap;gap:var(--stat-gap);justify-content:center}
+.stat{background:#f9fafb;border:1px solid var(--border);border-radius:12px;padding:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;text-align:center;min-width:var(--stat-min);max-width:var(--stat-max);flex:1 1 clamp(var(--stat-min),calc((100% - (2 * var(--stat-gap)))/3),var(--stat-max))}
 @media (max-width:520px){
   .row{flex-wrap:nowrap;gap:10px}
   .header-main{flex:1 1 auto;min-width:0}
   .title-select-wrap{padding-right:18px;flex:1 1 auto}
   .title-select{font-size:clamp(18px,5vw,22px)}
 }
+.stats::after{content:"";flex:1 1 calc((100% - (2 * var(--stat-gap)))/3);max-width:0}
+@media (max-width:720px){
+  .stats{justify-content:flex-start}
+}
+@media (max-width:600px){
+  :root{--stat-min:150px}
+}
+@media (max-width:520px){
+  .stats{gap:10px}
+}
 @media (max-width:480px){
-  .stats{gap:8px}
-  .stat{padding:10px;min-width:120px;flex:1 1 120px}
+  :root{--stat-gap:8px;--stat-min:120px}
+  .stat{padding:10px;flex:1 1 clamp(var(--stat-min),calc((100% - var(--stat-gap))/2),var(--stat-max))}
 }
 .stat .k{font-weight:700;font-size:18px}
 .stat .v{color:var(--muted);font-size:12px}


### PR DESCRIPTION
## Summary
- cap stat card width with new layout variables so they remain compact
- adjust stat row flex behavior to keep at least three cards per row while staying responsive

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9f7d517608321aadf35f344eca4a0