### PR TITLE
Restrict stat grid to two configurations

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 
 /* Stats */
 /* Stat layout */
-.stats{display:grid;gap:var(--stat-gap);grid-template-columns:repeat(auto-fit,minmax(var(--stat-min),1fr));align-items:stretch;justify-items:stretch;justify-content:center}
+.stats{display:grid;gap:var(--stat-gap);grid-template-columns:repeat(2,minmax(0,1fr));align-items:stretch;justify-items:stretch;justify-content:center}
 .stat{background:#f9fafb;border:1px solid var(--border);border-radius:12px;padding:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;text-align:center;min-width:0;width:100%}
 @media (max-width:520px){
   .row{flex-wrap:nowrap;gap:10px}
@@ -80,8 +80,8 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
   .title-select-wrap{padding-right:18px;flex:1 1 auto}
   .title-select{font-size:clamp(18px,5vw,22px)}
 }
-@media (min-width:721px){
-  .stats{grid-template-columns:repeat(3,minmax(var(--stat-min),var(--stat-max)))}
+@media (min-width:900px){
+  .stats{grid-template-columns:repeat(4,minmax(0,1fr))}
 }
 @media (max-width:600px){
   :root{--stat-min:150px}


### PR DESCRIPTION
## Summary
- constrain the stat grid to render only two configurations: 2x2 or a single row of four
- adjust the responsive breakpoint to switch from the 2-column grid to the 4-column layout on larger screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da02b986e0832191865352464c0e2a