### PR TITLE
Add toggle to show or hide downtime activities

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,7 @@ html,body,.grid,.grid .col,.card-bd{overflow-anchor:none}
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="2"/></svg>
         <input id="q" placeholder="Search adventures (name, code, notes, DM)"/>
       </div>
+      <button id="activityToggle" class="btn small" type="button" aria-pressed="false">Hide downtime activities</button>
       <button id="addCard" class="icon-btn" title="Add new adventure" aria-label="Add new adventure">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
       </button>
@@ -340,11 +341,42 @@ const statsEl  = document.getElementById('stats');
 const badgesEl = document.getElementById('charBadges');
 const metaEl   = document.getElementById('charMeta');
 const addCardBtn = document.getElementById('addCard');
+const activityToggleBtn = document.getElementById('activityToggle');
 const cardOverlay=document.getElementById('cardOverlay');
 let overlayCard=null;
 const ICON_TRASH='<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M5 6l1 14a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2l1-14"/></svg>';
 
 let pendingChanges=false;
+const STORAGE_KEYS={
+  showActivities:'al_logs_show_activities'
+};
+
+let showActivities=true;
+try{
+  const saved=localStorage.getItem(STORAGE_KEYS.showActivities);
+  if(saved==='0'||saved==='false') showActivities=false;
+}catch(err){
+  /* no-op */
+}
+
+function persistActivityVisibility(){
+  try{
+    localStorage.setItem(STORAGE_KEYS.showActivities, showActivities?'1':'0');
+  }catch(err){
+    /* no-op */
+  }
+}
+
+function updateActivityToggle(){
+  if(!activityToggleBtn) return;
+  const hiding=!showActivities;
+  activityToggleBtn.textContent=hiding?'Show downtime activities':'Hide downtime activities';
+  activityToggleBtn.setAttribute('aria-pressed', hiding?'true':'false');
+  activityToggleBtn.classList.toggle('primary', hiding);
+  const label=hiding?'Show downtime activities':'Hide downtime activities';
+  activityToggleBtn.setAttribute('aria-label', label);
+  activityToggleBtn.title=label;
+}
 
 function updateDownloadState(){
   if(!downloadBtn) return;
@@ -1515,6 +1547,7 @@ function filterAndRender(){
   const advs=(DATA.characters[key]&&DATA.characters[key].adventures)||[];
   const q=(qEl.value||'').toLowerCase();
   const filtered=advs.filter(a=>{
+    if(!showActivities && isActivityEntry(a)) return false;
     const blob=[a.title,a.code,a.notes,a.dm,a.traded_item,a.itemTraded,a.itemReceived,a.player,a.character]
       .concat(a.perm_items||[])
       .concat(a.consumable_items||[])
@@ -1529,6 +1562,14 @@ function filterAndRender(){
 /* --- events --- */
 qEl.addEventListener('input',filterAndRender);
 charSel.addEventListener('change',filterAndRender);
+if(activityToggleBtn){
+  activityToggleBtn.addEventListener('click',()=>{
+    showActivities=!showActivities;
+    persistActivityVisibility();
+    updateActivityToggle();
+    filterAndRender();
+  });
+}
 window.addEventListener('resize',()=>{
   const w=window.innerWidth||document.documentElement.clientWidth||0;
   if(Math.abs(w-__lastWidth)<8) return; __lastWidth=w;
@@ -1536,6 +1577,7 @@ window.addEventListener('resize',()=>{
 });
 
 /* --- init --- */
+updateActivityToggle();
 const firstKey=getMostRecentCharacter(); charSel.value=firstKey; filterAndRender();
 clearDirty();
 


### PR DESCRIPTION
## Summary
- add a toolbar toggle that can hide downtime activity cards from the grid
- persist the activity visibility choice in local storage and keep the toggle accessible
- update the rendering pipeline so the toggle state is respected when filtering adventures

## Testing
- Manual confirmation in browser

------
https://chatgpt.com/codex/tasks/task_e_68da0739a16c83218c0fa4a349e5f56f