### PR TITLE
Extend card header text to full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,8 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .card{display:block;background:#fff;border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow1);overflow:hidden;transition:transform var(--dur) var(--ease),box-shadow var(--dur) var(--ease)}
 .card:hover{transform:translateY(-3px);box-shadow:var(--shadow2)}
 .card-hd{display:flex;align-items:flex-start;justify-content:space-between;gap:10px;padding:14px;cursor:pointer;min-height:96px}
+.card-hd .titleLine,.card-hd .activity-line{flex:1 1 auto;min-width:0}
+.card-hd .titleLine{width:100%}
 .card-hd .card-tools{display:flex;align-items:center;gap:6px}
 .card .card-tools .icon-btn{opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-4px);transition:opacity var(--dur) var(--ease),transform var(--dur) var(--ease)}
 .card:hover .card-tools .icon-btn,
@@ -115,9 +117,11 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .card.editing{border-color:rgba(26,115,232,.35);box-shadow:0 0 0 2px rgba(26,115,232,.08)}
 .titleLine{display:flex;flex-direction:column}
 .date{color:var(--muted);line-height:16px}
-.title{font-weight:700;line-height:20px;height:20px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%}
+.title{font-weight:700;line-height:20px;height:20px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;width:100%}
 .subtitle{color:var(--muted);font-size:12px;margin-top:2px;line-height:16px;min-height:16px}
 .chips{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px;min-height:22px}
+.card:not(.open) .titleLine .chips{align-self:flex-end;margin-left:auto;text-align:right}
+.card.open .titleLine .chips{align-self:flex-start;margin-left:0;text-align:left}
 .pill{background:#fff7e6;color:#a05a00;border:1px solid #ffe3b0;border-radius:999px;padding:4px 8px;font-weight:700;font-size:11px}
 
 /* Collapsible */


### PR DESCRIPTION
## Summary
- allow card headers to expand across the full card width for both adventure and activity entries
- ensure long adventure titles are constrained and truncated with an ellipsis instead of overflowing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0af6033083219367d59569d6c8d5