### PR TITLE
Adjust card padding and chip alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 /* Card */
 .card{display:block;background:#fff;border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow1);overflow:hidden;transition:transform var(--dur) var(--ease),box-shadow var(--dur) var(--ease)}
 .card:hover{transform:translateY(-3px);box-shadow:var(--shadow2)}
-.card-hd{display:flex;align-items:flex-start;justify-content:flex-start;gap:10px;padding:14px;cursor:pointer;min-height:96px}
+.card-hd{display:flex;align-items:flex-start;justify-content:flex-start;gap:10px;padding:14px 12px 14px 14px;cursor:pointer;min-height:96px}
 .card-hd .titleLine,.card-hd .activity-line{flex:1 1 auto;min-width:0}
 .card-hd .titleLine{width:100%}
 .card-hd .card-tools{display:flex;align-items:center;gap:6px;margin-left:auto}
@@ -124,7 +124,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .subtitle-row .subtitle{margin-top:0}
 .subtitle-row .chips{margin-top:0;margin-left:auto;justify-content:flex-end}
 .card.open .subtitle-row{flex-wrap:wrap;gap:6px}
-.card.open .subtitle-row .chips{margin-left:0;justify-content:flex-start}
+.card.open .subtitle-row .chips{margin-left:auto;justify-content:flex-end}
 .pill{background:#fff7e6;color:#a05a00;border:1px solid #ffe3b0;border-radius:999px;padding:4px 8px;font-weight:700;font-size:11px}
 
 /* Collapsible */


### PR DESCRIPTION
## Summary
- reduce the right padding on card headers so adventure details can span the full width
- keep the GP chip aligned to the right even when a card is expanded

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da123f5cf083219d5cec5349185f4a