### PR TITLE
Update inventory header icon and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,14 +71,15 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 
 /* Header metrics */
 .header-quick{margin-top:14px;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
-.inventory-buttons{display:flex;align-items:center;gap:12px;margin-left:auto;flex-wrap:wrap}
-.inventory-stat{display:flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid var(--border);border-radius:12px;background:#fff;box-shadow:var(--shadow1);font-weight:700;color:var(--ink)}
+.inventory-buttons{display:flex;align-items:stretch;gap:12px;margin-left:auto;flex-wrap:wrap}
+.inventory-pill{display:flex;align-items:center;gap:10px;padding:10px 14px;border:1px solid var(--border);border-radius:12px;background:#fff;box-shadow:var(--shadow1);font-weight:700;color:var(--ink);position:relative;min-height:52px}
+.inventory-stat{display:flex;flex-direction:column;align-items:flex-start;justify-content:center;gap:2px}
 .inventory-stat .label{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600}
 .inventory-stat .value{font-size:18px;letter-spacing:-0.01em}
-.inventory-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:6px;border-radius:12px;color:var(--muted);cursor:pointer;transition:color var(--dur) var(--ease),background var(--dur) var(--ease);background:transparent;line-height:0;outline:none}
+.inventory-btn{display:inline-flex;align-items:center;justify-content:center;border-radius:12px;color:var(--muted);cursor:pointer;transition:color var(--dur) var(--ease),box-shadow var(--dur) var(--ease),transform var(--dur) var(--ease);line-height:0;outline:none}
 .inventory-btn svg{width:26px;height:26px;pointer-events:none}
-.inventory-btn:hover{color:var(--primary);background:rgba(26,115,232,.08)}
-.inventory-btn:focus-visible{box-shadow:0 0 0 2px rgba(26,115,232,.35);background:rgba(26,115,232,.1)}
+.inventory-btn:hover{color:var(--primary);box-shadow:var(--shadow2);transform:translateY(-1px)}
+.inventory-btn:focus-visible{box-shadow:0 0 0 2px rgba(26,115,232,.35),var(--shadow1)}
 .inventory-btn .badge{position:absolute;top:-6px;right:-6px;min-width:22px;padding:2px 6px;border-radius:999px;background:var(--primary);color:#fff;font-size:11px;font-weight:700;line-height:1;text-align:center;box-shadow:0 6px 16px rgba(26,115,232,.35);}
 @media (max-width:520px){
   .row{flex-wrap:nowrap;gap:10px}
@@ -292,15 +293,17 @@ html,body,.grid,.grid .col,.card-bd{overflow-anchor:none}
     </div>
     <div class="header-quick" id="headerQuick">
       <div class="inventory-buttons">
-        <div id="magicItemsBtn" class="inventory-btn" role="button" tabindex="0" title="View permanent magic items" aria-label="View permanent magic items">
+        <div id="magicItemsBtn" class="inventory-btn inventory-pill" role="button" tabindex="0" title="View permanent magic items" aria-label="View permanent magic items">
           <span class="sr-only">View permanent magic items</span>
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="m12 3 1.76 3.57 3.94.57-2.85 2.78.67 3.9L12 12.97l-3.52 1.85.67-3.9-2.85-2.78 3.94-.57L12 3Z"/>
-            <path d="M6 20c1.2-.8 3.4-1.6 6-1.6s4.8.8 6 1.6"/>
+            <path d="M5 10V7a3 3 0 0 1 3-3h8a3 3 0 0 1 3 3v3"/>
+            <path d="M4 10h16v9H4z"/>
+            <path d="M12 10v3"/>
+            <path d="M9 13h6"/>
           </svg>
           <span class="badge" id="magicItemsCount" aria-hidden="true">0</span>
         </div>
-        <div id="consumablesBtn" class="inventory-btn" role="button" tabindex="0" title="View consumables" aria-label="View consumables">
+        <div id="consumablesBtn" class="inventory-btn inventory-pill" role="button" tabindex="0" title="View consumables" aria-label="View consumables">
           <span class="sr-only">View consumables</span>
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M9 3h6"/>
@@ -310,11 +313,11 @@ html,body,.grid,.grid .col,.card-bd{overflow-anchor:none}
           </svg>
           <span class="badge" id="consumablesCount" aria-hidden="true">0</span>
         </div>
-        <div class="inventory-stat" id="goldMetric" role="group" aria-label="Gold pieces total">
+        <div class="inventory-stat inventory-pill" id="goldMetric" role="group" aria-label="Gold pieces total">
           <span class="label">Gold</span>
           <span class="value" id="goldValue">0</span>
         </div>
-        <div class="inventory-stat" id="downtimeMetric" role="group" aria-label="Downtime days total">
+        <div class="inventory-stat inventory-pill" id="downtimeMetric" role="group" aria-label="Downtime days total">
           <span class="label">Downtime</span>
           <span class="value" id="downtimeValue">0</span>
         </div>


### PR DESCRIPTION
## Summary
- replace the permanent magic item button icon with a chest illustration
- introduce shared styling so inventory buttons and metrics render with uniform sizing

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dab22f2ab88321acb6fa446eb71588