### PR TITLE
Restore avatar overlay behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@ html,body{margin:0;padding:0;font-family:Inter,ui-sans-serif,system-ui,-apple-sy
 .container{max-width:1200px;margin:28px auto 80px;padding:0 20px 120px}
 .header{position:relative;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:16px;box-shadow:var(--shadow1)}
 .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
-.avatar{width:72px;height:72px;border-radius:50%;background:none;box-shadow:0 10px 28px rgba(15,23,42,.22);background-size:cover;background-position:center;background-repeat:no-repeat;overflow:hidden;transition:transform var(--dur) var(--ease)}
-.avatar.has-avatar{cursor:zoom-in;}
+.avatar{display:block;width:auto;height:72px;max-width:100%;border-radius:0;box-shadow:none;object-fit:contain}
+.avatar.has-avatar{cursor:pointer;}
 .avatar:focus-visible{outline:2px solid rgba(26,115,232,.35);outline-offset:3px}
 h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01em}
 .header-main{display:flex;flex-direction:column;gap:6px;min-width:0;flex:1 1 auto}
@@ -269,7 +269,7 @@ body.avatar-overlay-open{overflow:hidden}
 <div class="container">
   <section class="header">
     <div class="row">
-      <div id="charAvatar" class="avatar" role="button" tabindex="0" aria-label="View character avatar"></div>
+      <img id="charAvatar" class="avatar" alt="Character avatar" role="button" tabindex="0" aria-label="View character avatar"/>
       <div class="header-main">
         <h1 class="title-select-wrap" id="charTitle">
           <label for="charSel" class="sr-only">Select a sheet or character</label>
@@ -706,22 +706,23 @@ if(avatarEl){
 
 function resetAvatar(){
   if(!avatarEl) return;
-  avatarEl.style.removeProperty('background-image');
+  avatarEl.removeAttribute('src');
   avatarEl.classList.remove('has-avatar');
   avatarEl.removeAttribute('data-avatar-src');
+  avatarEl.alt='Character avatar';
   avatarEl.setAttribute('aria-label','View character avatar');
   closeAvatarOverlay({returnFocus:false});
 }
 function applyAvatar(path,token){
   if(!avatarEl || token!==avatarLoadToken) return;
-  const safePath=String(path).replace(/(["'\\)])/g,'\\$1');
-  avatarEl.style.backgroundImage=`url('${safePath}')`;
+  avatarEl.src=path;
   avatarEl.classList.add('has-avatar');
   avatarEl.setAttribute('data-avatar-src',path);
   const selectedOption=charSel && charSel.options && charSel.selectedIndex>=0 ? charSel.options[charSel.selectedIndex] : null;
   const optionLabel=selectedOption?selectedOption.textContent.trim():'';
-  const label=optionLabel?`View ${optionLabel} avatar`:'View character avatar';
-  avatarEl.setAttribute('aria-label',label);
+  const label=optionLabel?`${optionLabel} avatar`:'Character avatar';
+  avatarEl.alt=label;
+  avatarEl.setAttribute('aria-label', optionLabel?`View ${optionLabel} avatar`:'View character avatar');
 }
 function updateAvatar(key,obj){
   if(!avatarEl){


### PR DESCRIPTION
## Summary
- keep the header avatar as a plain PNG while restoring button semantics for expanding it
- wire the avatar image back to the overlay viewer and update its aria-labels when the source changes

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dacc5548d883219567444d2b0f4913