### PR TITLE
Add consistent CORS handling and refresh data cache after save

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,6 +632,11 @@ async function saveDataJs(options={}){
     }
     clearDirty();
     setSaveResult('success');
+    try{
+      await refreshDataJsCache();
+    }catch(err){
+      console.warn('Unable to refresh data.js cache after save', err);
+    }
     return body;
   }catch(err){
     console.error('Failed to save data.js', err);
@@ -645,6 +650,14 @@ async function saveDataJs(options={}){
     savingData=false;
     updateSaveButtonState();
   }
+}
+
+async function refreshDataJsCache(){
+  const response=await fetch('data.js',{ cache:'reload', headers:{ 'cache-control':'no-cache', pragma:'no-cache' } });
+  if(!response.ok){
+    throw new Error('HTTP '+response.status);
+  }
+  await response.text();
 }
 
 /* --- character selector (no session counts) --- */


### PR DESCRIPTION
## Summary
- handle OPTIONS preflight requests for the save-data API with the required CORS headers
- refactor responses to reuse a helper that attaches the shared CORS header set for success and error cases
- refresh the cached data.js asset after saving so reloads pick up the latest data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad4baff188321a08d9b02b1886ace