### PR TITLE
Hide edit action buttons when not editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .list-editor .add-row{align-self:flex-start;border:1px dashed var(--border);background:#f8fafc;color:var(--primary);border-radius:10px;padding:6px 10px;font-size:12px;cursor:pointer}
 .list-editor .add-row:hover{background:#eef4ff}
 .edit-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px;flex-wrap:wrap}
+.card:not(.editing) .edit-actions{display:none}
 .card.editing .edit-actions{display:flex}
 .edit-actions .delete-btn{margin-right:auto}
 


### PR DESCRIPTION
## Summary
- hide card edit action buttons while the card is not in editing mode by scoping their display rule

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db01e0e1cc8321b5d8ac33dd54d3fc