### PR TITLE
Adjust title inline editor sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .card.editing .editable-inline .display{display:none}
 .card.editing .editable-inline .editor{display:flex;width:100%}
 .card.editing .editable-inline .editor > *{flex:1 1 auto;width:100%;min-width:0}
-.editable-inline .editor input,.editable-inline .editor select{font:inherit;padding:4px 6px;border:1px solid var(--border);border-radius:10px;outline:none;background:#fff;max-width:100%;min-width:0;box-shadow:none}
+.editable-inline .editor input,.editable-inline .editor select{font:inherit;padding:6px 8px;line-height:1.3;border:1px solid var(--border);border-radius:10px;outline:none;background:#fff;max-width:100%;min-width:0;box-shadow:none;min-height:calc(1em + 12px)}
 .editable-inline .editor input{min-width:0;max-width:100%}
 .card.editing .subtitle-row{flex-wrap:wrap;align-items:flex-start;gap:6px}
 .card.editing .subtitle-row .subtitle{width:100%;min-width:0}


### PR DESCRIPTION
## Summary
- increase the padding and line-height for inline editor inputs so the title text fits comfortably

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68db091cd15083218f197c5a71326958