### PR TITLE
Adjust character selector caret alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,9 @@ html,body{margin:0;padding:0;font-family:Inter,ui-sans-serif,system-ui,-apple-sy
 .avatar:focus-visible{outline:2px solid rgba(26,115,232,.35);outline-offset:3px}
 h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01em}
 .header-main{display:flex;flex-direction:column;gap:6px;min-width:0;flex:1 1 auto}
-.title-select-wrap{display:flex;align-items:center;gap:8px;position:relative;padding-right:16px;max-width:100%;min-width:0}
-.title-select-wrap::after{content:"";width:12px;height:8px;clip-path:polygon(0 0,100% 0,50% 100%);background:currentColor;opacity:.55;transition:opacity var(--dur) var(--ease),transform var(--dur) var(--ease);pointer-events:none;position:absolute;right:2px;top:50%;transform:translateY(-50%)}
-.title-select-wrap:focus-within::after{opacity:1;transform:translateY(-40%)}
+.title-select-wrap{display:flex;align-items:center;gap:6px;position:relative;max-width:100%;min-width:0}
+.title-select-wrap::after{content:"";flex-shrink:0;width:12px;height:8px;clip-path:polygon(0 0,100% 0,50% 100%);background:currentColor;opacity:.55;transition:opacity var(--dur) var(--ease),transform var(--dur) var(--ease);pointer-events:none;transform:translateY(0)}
+.title-select-wrap:focus-within::after{opacity:1;transform:translateY(-2px)}
 .title-select{appearance:none;border:none;background:transparent;font:inherit;color:var(--ink);padding:0;margin:0;cursor:pointer;line-height:1.1;font-weight:800;letter-spacing:-0.01em;max-width:100%;min-width:0;font-size:clamp(20px,4vw,28px);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .title-select:focus-visible{outline:2px solid rgba(26,115,232,.35);outline-offset:2px;border-radius:6px}
 .title-select option{color:var(--ink)}
@@ -89,7 +89,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 @media (max-width:520px){
   .row{flex-wrap:nowrap;gap:10px}
   .header-main{flex:1 1 auto;min-width:0}
-  .title-select-wrap{padding-right:18px;flex:1 1 auto}
+  .title-select-wrap{flex:1 1 auto}
   .title-select{font-size:clamp(18px,5vw,22px)}
   .header-quick{flex-direction:column;align-items:flex-start;gap:12px}
   .inventory-buttons{margin-left:0}


### PR DESCRIPTION
## Summary
- align the character selector dropdown caret directly after the character name by letting the caret pseudo-element follow the text instead of being absolutely positioned
- clean up mobile-specific padding so the inline caret layout is consistent at smaller viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db34090f14832198f05db9f1913e5b