### PR TITLE
fix: enforce configured branch in save-data edge function

### DIFF
--- a/api/save-data.js
+++ b/api/save-data.js
@@ -28,9 +28,14 @@ export default async function handler(req) {
   }
 
   try {
-    const { dataJs, branch = process.env.GH_BRANCH || 'work', path = 'data.js' } = await req.json();
+    const { dataJs, path = 'data.js' } = await req.json();
     if (!dataJs || typeof dataJs !== 'string') {
       return respond({ error: 'dataJs (string) required' }, { status: 400 });
+    }
+
+    const branch = process.env.GH_BRANCH || 'work';
+    if (!branch || branch === 'main') {
+      return respond({ error: 'Invalid branch configuration' }, { status: 500 });
     }
 
     const repo = process.env.GH_REPO;   // e.g. "Lebowskigrande/AL-logs"


### PR DESCRIPTION
## Summary
- read the target branch from configuration instead of the client payload
- validate the resolved branch and block commits when it is misconfigured
- use the sanitized branch for the current SHA lookup and commit creation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db3ad317308321a7204d26ffd57ccd