### PR TITLE
Update save button visuals and feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,13 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .icon-btn.primary{background:var(--primary);color:#fff;border-color:var(--primary)}
 .icon-btn.primary:hover{box-shadow:var(--shadow2)}
 .icon-btn[disabled]{opacity:.5;cursor:not-allowed;box-shadow:none;background:#f1f5f9;color:#94a3b8}
-.download-btn{margin-left:auto;align-self:flex-start;width:auto;height:auto;padding:0;border:none;border-radius:0;background:transparent;box-shadow:none;color:var(--primary)}
-.download-btn svg{width:20px;height:20px}
+.download-btn{margin-left:auto;align-self:flex-start;display:inline-flex;align-items:center;justify-content:center;gap:6px;width:auto;height:32px;padding:0 12px;border:none;border-radius:999px;background:transparent;box-shadow:none;color:var(--primary);font-weight:600;font-size:13px;line-height:1}
+.download-btn .save-icon,.download-btn .save-spinner,.download-btn .save-success{display:none;align-items:center;justify-content:center;gap:6px}
+.download-btn .save-icon svg,.download-btn .save-spinner svg{width:20px;height:20px}
+.download-btn .save-success{letter-spacing:.01em}
+.download-btn:not(.saving):not(.success) .save-icon{display:inline-flex}
+.download-btn.saving .save-spinner{display:inline-flex}
+.download-btn.success .save-success{display:inline-flex}
 .download-btn::after{content:none}
 .download-btn:hover{color:#1257b3}
 .download-btn.dirty{color:#0b3f88;background:transparent}
@@ -73,6 +78,12 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 .download-btn.saving{color:var(--muted);cursor:progress}
 .download-btn.success{color:#15803d}
 .download-btn.error{color:var(--danger)}
+.download-btn .save-spinner svg{animation:save-spin 900ms linear infinite}
+
+@keyframes save-spin{
+  0%{transform:rotate(0)}
+  100%{transform:rotate(360deg)}
+}
 
 /* Header metrics */
 .header-quick{margin-top:14px;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
@@ -316,7 +327,20 @@ body.avatar-overlay-open{overflow:hidden}
         <div id="charBadges" class="char-badges" aria-live="polite"></div>
       </div>
       <button id="downloadData" class="icon-btn download-btn" type="button" title="Save data.js" aria-label="Save data.js">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="m7 12 5 5 5-5"/><path d="M5 21h14"/></svg>
+        <span class="save-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 3h9l4 4v13H6a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3Z"/>
+            <path d="M15 3v5H6V3"/>
+            <path d="M9 14h6v5H9z"/>
+          </svg>
+        </span>
+        <span class="save-spinner" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="9" stroke-opacity=".3"/>
+            <path d="M21 12a9 9 0 0 0-9-9"/>
+          </svg>
+        </span>
+        <span class="save-success" aria-hidden="true">Saved</span>
       </button>
     </div>
     <div class="toolbar">


### PR DESCRIPTION
## Summary
- replace the save button icon with a floppy disk glyph
- show a spinner while data is being saved and display a brief “Saved” confirmation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db877a94dc8321b75080a7cd704f5d