### PR TITLE
Style consumable chips for potions and scrolls

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,8 @@ body.modal-open #addCard{display:none;}
 .inv-name.consumable-name .cons-name{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .inv-name.consumable-name .cons-chips{flex-shrink:0;display:inline-flex;gap:6px}
 .inv-name.consumable-name .cons-chip{display:inline-flex;align-items:center;padding:2px 6px;border-radius:999px;border:1px solid rgba(26,115,232,.2);background:rgba(26,115,232,.12);color:#1e3a8a;font-size:10px;font-weight:600;letter-spacing:.08em;text-transform:uppercase}
+.inv-name.consumable-name .cons-chip--potion{border-color:rgba(34,197,94,.35);background:rgba(220,252,231,1);color:#166534}
+.inv-name.consumable-name .cons-chip--scroll{border-color:rgba(129,140,248,.4);background:rgba(237,233,254,1);color:#3730a3}
 .inv-tools{display:flex;align-items:center;gap:6px}
 .inv-row .delete-btn{display:none;margin-left:8px}
 .modal.editing .inv-row{cursor:default}
@@ -1578,6 +1580,8 @@ function openConsumableModal(charKey){
       chips.forEach(chip=>{
         const chipEl=document.createElement('span');
         chipEl.className='cons-chip';
+        const slug=chip.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'');
+        if(slug){ chipEl.classList.add(`cons-chip--${slug}`); }
         chipEl.textContent=chip;
         chipWrap.appendChild(chipEl);
       });


### PR DESCRIPTION
## Summary
- add slug-based classes to consumable chips so potion and scroll tags can be targeted
- style potion and scroll consumable chips with distinct colors for easier scanning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc032b80e08321baa50af89db0f2ed