### PR TITLE
Align consumable chips with item names

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,8 +275,9 @@ body.modal-open #addCard{display:none;}
 .inv-row.active{background:#e8f0ff;font-weight:600}
 .inv-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .inv-name.consumable-name{display:flex;flex-direction:column;align-items:flex-start;gap:4px;min-width:0}
-.inv-name.consumable-name .cons-name{display:block;font-weight:600;min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.inv-name.consumable-name .cons-chips{display:flex;flex-wrap:wrap;gap:6px;margin:0}
+.inv-name.consumable-name .cons-primary{display:flex;align-items:center;gap:6px;flex-wrap:wrap;min-width:0}
+.inv-name.consumable-name .cons-name{display:inline-block;font-weight:600;min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inv-name.consumable-name .cons-chips{display:inline-flex;flex-wrap:wrap;gap:6px;margin-left:6px}
 .inv-tools{display:flex;align-items:center;gap:6px}
 .inv-row .delete-btn{display:none;margin-left:8px}
 .modal.editing .inv-row{cursor:default}
@@ -304,7 +305,7 @@ body.modal-open #addCard{display:none;}
 .cons-section-title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:0 4px}
 .cons-sublist{display:flex;flex-direction:column;gap:6px}
 .cons-name{display:block;font-weight:600}
-.cons-chips{display:inline-flex;gap:6px;margin-left:8px;flex-wrap:wrap;align-items:center}
+.cons-chips{display:inline-flex;gap:6px;margin-left:6px;flex-wrap:wrap;align-items:center}
 .cons-chip{display:inline-flex;align-items:center;justify-content:center;padding:2px 6px;border-radius:999px;background:#eef4ff;color:#1e3a8a;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.08em}
 .cons-chip--potion{background:#fef3c7;color:#b45309}
 .cons-chip--scroll{background:#ede9fe;color:#5b21b6}
@@ -1666,10 +1667,12 @@ function openConsumableModal(charKey){
     const nameDiv=document.createElement('div');
     nameDiv.className='inv-name consumable-name';
     const {label:displayLabel,chips}=formatConsumableDisplay(name);
+    const primary=document.createElement('div');
+    primary.className='cons-primary';
     const labelSpan=document.createElement('span');
     labelSpan.className='cons-name';
     labelSpan.textContent=displayLabel||name;
-    nameDiv.appendChild(labelSpan);
+    primary.appendChild(labelSpan);
     if(Array.isArray(chips) && chips.length){
       const chipWrap=document.createElement('span');
       chipWrap.className='cons-chips';
@@ -1681,8 +1684,9 @@ function openConsumableModal(charKey){
         chipEl.textContent=chip;
         chipWrap.appendChild(chipEl);
       });
-      nameDiv.appendChild(chipWrap);
+      primary.appendChild(chipWrap);
     }
+    nameDiv.appendChild(primary);
     return {element:nameDiv,label:labelSpan.textContent};
   };
 


### PR DESCRIPTION
## Summary
- keep consumable chips on the same line as their item names to reduce card height
- adjust consumable name layout structure and styles to support the inline chip presentation

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc1a3d63048321bfbde5ecc0f1a1e3