### PR TITLE
Discard local drafts when navigating away

### DIFF
--- a/index.html
+++ b/index.html
@@ -828,6 +828,16 @@ function clearDataDraft(){
     /* no-op */
   }
 }
+
+function discardDraftBeforeNavigation(){
+  if(!(pendingChanges || hasLocalDraft)) return;
+  clearDataDraft();
+}
+
+if(typeof window!=='undefined'){
+  window.addEventListener('pagehide',discardDraftBeforeNavigation);
+  window.addEventListener('unload',discardDraftBeforeNavigation);
+}
 function applyDraftIfAvailable(){
   if(draftStateApplied) return;
   draftStateApplied=true;
@@ -3241,7 +3251,7 @@ window.addEventListener('resize',()=>{
 });
 window.addEventListener('beforeunload',(event)=>{
   if(pendingChanges || hasLocalDraft){
-    const message='You have unsaved changes. Save them before leaving or continue to discard them.';
+    const message='You have unsaved changes. Save them before leaving or they will be discarded.';
     event.preventDefault();
     event.returnValue=message;
     return message;


### PR DESCRIPTION
## Summary
- clear any locally saved draft data when navigating away with unsaved changes so the next load uses the server copy
- clarify the unload warning copy to indicate local changes will be discarded if not saved

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df0d8c60a0832187ce4c48c883899e