### PR TITLE
Switch new entry controls to floating menu

### DIFF
--- a/analysis/dm_reward_verification.json
+++ b/analysis/dm_reward_verification.json
@@ -1,0 +1,2138 @@
+{
+  "analysis": [
+    {
+      "character": "Agatha",
+      "dm_log": [
+        {
+          "date": "2024-09-11T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "3 levels to Agatha",
+          "season": "50th Anniversary Season B"
+        },
+        {
+          "date": "2025-04-25T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Ring of Invisibility + 40 DTD to Agatha",
+          "season": "Service Awards 2025"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2025-05-14",
+          "title": "DM Reward",
+          "perm_items": [
+            "Ring of Invisibility"
+          ],
+          "level_plus": null,
+          "dtd_net": 40,
+          "notes": null
+        },
+        {
+          "date": "2024-09-11",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 3,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Anfer",
+      "dm_log": [
+        {
+          "date": "2021-02-04T00:00:00",
+          "code": "CCC-MCX-01-02",
+          "name": "The Rescue",
+          "item": "Cape of Billowing",
+          "allocation": "Level to Anfer",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Arvistan Brightwave",
+      "dm_log": [
+        {
+          "date": "2025-05-28T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Player rewards: Arcane Grimoire +3 and Blessing of Protection to Arvistan",
+          "season": "Service Awards 2025"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2025-05-28",
+          "title": "DM Reward",
+          "perm_items": [
+            "Arcane Grimoire +3",
+            "Blessing of Protection"
+          ],
+          "level_plus": null,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2020-11-01",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Buckley",
+      "dm_log": [
+        {
+          "date": "2020-03-03T00:00:00",
+          "code": "DDAL 09-01",
+          "name": "Escape from Elturguard",
+          "item": "Amulet of Proof Against Detection",
+          "allocation": "Levels to Darrendrian (x2), Morty, Buckley",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2020-03-03",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 10,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Chef Ture",
+      "dm_log": [
+        {
+          "date": "2024-09-01T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Boomerang Shield + 10 DTD to Chef Ture",
+          "season": "50th Anniversary Season B"
+        },
+        {
+          "date": "2024-09-01T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Rare reward (Flametongue Warhammer) + 2500gp to Chef Ture",
+          "season": "50th Anniversary Season B"
+        }
+      ],
+      "char_log": [
+        {
+          "date": null,
+          "title": "DM Reward x 2",
+          "perm_items": [
+            "Boomerang Shield",
+            "Flametongue Warhammer"
+          ],
+          "level_plus": 1,
+          "dtd_net": 10,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Creature X-12",
+      "dm_log": [
+        {
+          "date": "2020-09-08T00:00:00",
+          "code": "DDHC-TYP",
+          "name": "Chapter 3 pt. 2",
+          "item": "Wand of Lightning Bolts, Hat of Disguise, Eagle Whistle, Dagger +1 (broken), Dagger +1, Mace +1 (broken), Stone of Ill Luck",
+          "allocation": "Hat of Disuise to Creature X-12",
+          "season": "preS11"
+        },
+        {
+          "date": "2022-07-03T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Level to Creature X-12",
+          "season": "Season 11b"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2023-07-06",
+          "title": "DM Reward (x2)",
+          "perm_items": [
+            "Hat of Disguise"
+          ],
+          "level_plus": 1,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Darrendrian",
+      "dm_log": [
+        {
+          "date": "2020-03-03T00:00:00",
+          "code": "DDAL 09-01",
+          "name": "Escape from Elturguard",
+          "item": "Amulet of Proof Against Detection",
+          "allocation": "Levels to Darrendrian (x2), Morty, Buckley",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-06-20T00:00:00",
+          "code": "CCC-SALT-02-05",
+          "name": "The Darkness Never Forgets",
+          "item": "Cape of the Mountbank",
+          "allocation": "Item to Darrendrian",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-09-19T00:00:00",
+          "code": "DDHC-TYP",
+          "name": "Chapter 3 pt. 2",
+          "item": "Wand of Lightning Bolts, Hat of Disguise, Eagle Whistle",
+          "allocation": "Item to Darrendrian",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-10-03",
+          "title": "DM Reward",
+          "perm_items": [
+            "Wand of Lightning Bolts"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-06-26",
+          "title": "DM Reward",
+          "perm_items": [
+            "Cape of the Mountbank"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-03-06",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": null,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-03-03",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": null,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Dolroruuk",
+      "dm_log": [
+        {
+          "date": "2021-05-25T00:00:00",
+          "code": "CCC-BMG-MOON-6-2",
+          "name": "Troubled Visions",
+          "item": "Boots of Elvenkind, Moon Touched Rapier",
+          "allocation": "Level to Dolroruuk",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-05-31T00:00:00",
+          "code": "CCC-BMG-MOON-6-3",
+          "name": "Planar Convergance",
+          "item": "Javeline of Lightning, Horn of Silent Alarm",
+          "allocation": "Level to Dolroruuk",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-09-15T00:00:00",
+          "code": "CCC-DES-01-02",
+          "name": "A Sanity Never Questioned",
+          "item": "Staff of Healing (Driftwood staff)",
+          "allocation": "Level to Dolroruuk",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": null,
+          "title": "DM Reward x 3",
+          "perm_items": [],
+          "level_plus": 3,
+          "dtd_net": 30,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Gnat",
+      "dm_log": [
+        {
+          "date": "2021-09-03T00:00:00",
+          "code": "DRW-09",
+          "name": "Vile Bounty",
+          "item": "Amulet of Health, Mariner's Studded Leather",
+          "allocation": "Item to Gnat",
+          "season": "preS11"
+        },
+        {
+          "date": "2028-07-14T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Rare reward (Vicious Glavie) to Gnat + 2500 gp",
+          "season": "50th Anniversary Season B"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-09-29",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2021-09-29",
+          "title": "DM Reward",
+          "perm_items": [
+            "Marvelous Pigments"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-09-29",
+          "title": "DM Reward",
+          "perm_items": [
+            "Bracers of Defense"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": null,
+          "title": "DM Reward",
+          "perm_items": [
+            "Amulet of Health"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": null,
+          "title": "DM Reward",
+          "perm_items": [
+            "Vicious Glaive"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Goblert Godfrey",
+      "dm_log": [
+        {
+          "date": "2021-10-19T00:00:00",
+          "code": "DDHC-TOA-9",
+          "name": "Ruins of Matolo",
+          "item": "Marvelous Pigments, Bronze Griffon, +1 Scimitar, 2310 gp",
+          "allocation": "Item to (Pigments) to Goblert",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2022-01-15",
+          "title": "DM Reward",
+          "perm_items": [
+            "Nolzur's Pigments"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Leonardo",
+      "dm_log": [
+        {
+          "date": "2020-06-06T00:00:00",
+          "code": "CCC-CIC-10",
+          "name": "Terror at Soward Manor",
+          "item": "Bracers of Defense",
+          "allocation": "Item to Leonardo",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2020-07-19",
+          "title": "DM Reward",
+          "perm_items": [
+            "Bracers of Defense"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Lorien",
+      "dm_log": [
+        {
+          "date": "2020-05-16T00:00:00",
+          "code": "DDAL 09-04",
+          "name": "Day of the Devil",
+          "item": "Periapt of Health",
+          "allocation": "Level to Lorien",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-06-25T00:00:00",
+          "code": "CCC-ELF-001",
+          "name": "Life's a Party",
+          "item": "Ring of Warmth",
+          "allocation": "Level to Lorien",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-07-04T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Arrow-Catching Shield",
+          "allocation": "Level to Lorien",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2020-07-13",
+          "title": "DM Rewards x3",
+          "perm_items": [],
+          "level_plus": 3,
+          "dtd_net": 60,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Lyrielle",
+      "dm_log": [
+        {
+          "date": "2021-05-09T00:00:00",
+          "code": "CCC-BMG-MOON6-3",
+          "name": "A Reopened Eye",
+          "item": "Fey Cloak of Protection",
+          "allocation": "Item to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-05-19T00:00:00",
+          "code": "CCC-CIC-15",
+          "name": "Den of the Dead Witch",
+          "item": "Necklace of Fireballs (6)",
+          "allocation": "Item to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-06-23T00:00:00",
+          "code": "CCC-ELF-001",
+          "name": "Life's a Party",
+          "item": "Ring of Warmth",
+          "allocation": "Level to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-06-26T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Arrow-Catching Shield",
+          "allocation": "Level to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-06-27T00:00:00",
+          "code": "CCC-BMG-MOON-6-3",
+          "name": "Planar Convergance",
+          "item": "Javeline of Lightning, Horn of Silent Alarm",
+          "allocation": "Level to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-06-30T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Arrow-Catching Shield",
+          "allocation": "Level to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-07-12T00:00:00",
+          "code": "CCC-MCX-01-02",
+          "name": "The Rescue",
+          "item": "",
+          "allocation": "Level to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-07-28T00:00:00",
+          "code": "DC-PoA-DCAF01",
+          "name": "Let it Goat",
+          "item": "Boots of the Winterlands, Pole of Angling",
+          "allocation": "Level to Lyrielle",
+          "season": "preS11"
+        },
+        {
+          "date": "2022-07-08T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Levels to Lyrielle",
+          "season": "Season 11b"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2022-07-04",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 6,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-09-04",
+          "title": "DM Reward x 2",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 40,
+          "notes": null
+        },
+        {
+          "date": "2021-08-27",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2021-07-15",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2021-07-15",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2021-07-15",
+          "title": "DM Reward",
+          "perm_items": [
+            "Fey Cloak of Protection"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-07-06",
+          "title": "DM Reward x 3",
+          "perm_items": [],
+          "level_plus": 3,
+          "dtd_net": 30,
+          "notes": "Purchased Bruce the Elephant for 200 gp"
+        },
+        {
+          "date": "2021-07-06",
+          "title": "DM Reward",
+          "perm_items": [
+            "Necklace of Fireballs"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Madam Renata",
+      "dm_log": [
+        {
+          "date": "2021-05-28T00:00:00",
+          "code": "CCC-BMG-MOON-6-3",
+          "name": "Planar Convergance",
+          "item": "Javeline of Lightning, Horn of Silent Alarm",
+          "allocation": "Level to Madam Renata",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-09-03T00:00:00",
+          "code": "DDEX02-10",
+          "name": "Cloaks and Shadows",
+          "item": "Winged Boots",
+          "allocation": "Item to Madam Renata",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-09-08T00:00:00",
+          "code": "CCC-DES-01-01",
+          "name": "Finding the Rabbit Hole",
+          "item": "FOWP - Ivory Goats",
+          "allocation": "Level to Madam Renata",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-09-24",
+          "title": "DM Reward x 3",
+          "perm_items": [],
+          "level_plus": 3,
+          "dtd_net": 30,
+          "notes": null
+        },
+        {
+          "date": "2021-09-24",
+          "title": "DM Reward",
+          "perm_items": [
+            "Winged Boots"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Morty",
+      "dm_log": [
+        {
+          "date": "2020-03-03T00:00:00",
+          "code": "DDAL 09-01",
+          "name": "Escape from Elturguard",
+          "item": "Amulet of Proof Against Detection",
+          "allocation": "Levels to Darrendrian (x2), Morty, Buckley",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-03-28T00:00:00",
+          "code": "DDAL 09-01",
+          "name": "Escape from Elturguard",
+          "item": "Amulet of Proof Against Detection",
+          "allocation": "Levels to Zandarax (x2), Morty, S9 reward (Tressym) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-06-18T00:00:00",
+          "code": "CCC-CIC-10",
+          "name": "Terror at Soward Manor",
+          "item": "Bracers of Defense",
+          "allocation": "Level to Morty",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-08-06T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Ring of Warmth",
+          "allocation": "Level to Morty",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2020-08-08",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-08-08",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-08-08",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-03-25",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 10,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Noraggen",
+      "dm_log": [
+        {
+          "date": "2020-05-21T00:00:00",
+          "code": "DDAL 09-04",
+          "name": "Day of the Devil",
+          "item": "Periapt of Health",
+          "allocation": "Level to Noraggen",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-06-05T00:00:00",
+          "code": "Playtest",
+          "name": "Tier 4 w/ Jon K.",
+          "item": "",
+          "allocation": "Level to Noraggen",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-08-12T00:00:00",
+          "code": "CCC-BLD 1-1",
+          "name": "Bleeding Gate: Pandemonium",
+          "item": "Periapt of Wound Closure",
+          "allocation": "Level to Noraggen",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-08-15T00:00:00",
+          "code": "CCC-CIC-10",
+          "name": "Terror at Soward Manor",
+          "item": "Bracers of Defense",
+          "allocation": "Level to Noraggen",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-11-15T00:00:00",
+          "code": "DDHC-TYP",
+          "name": "Chapter 3",
+          "item": "Tloque's Battleaxe, Bracelet of Rock Magic, Eagle Whistle",
+          "allocation": "Item (Battleaxe) to Noraggen",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-18T00:00:00",
+          "code": "CCC-BMG-22 PHLAN2-1",
+          "name": "Demagogue",
+          "item": "Tyr's Blessing of the Mind",
+          "allocation": "Level to Noraggen",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-04-01",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-11-18",
+          "title": "DM Reward (x4)",
+          "perm_items": [],
+          "level_plus": 4,
+          "dtd_net": 40,
+          "notes": null
+        },
+        {
+          "date": "2020-11-18",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-11-18",
+          "title": "DM Reward",
+          "perm_items": [
+            "Tloque's Battleaxe"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Norixius",
+      "dm_log": [
+        {
+          "date": "2022-03-07T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Dragon slayer greatsword + 20 DTD to Norixius",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-03-09T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Giant slayer greatsword + 2500 gp to Norixius",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-04-07T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Flametongue greatsword + 2500 gp to Norixius",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2023-04-26T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Sixth Sword + 2500gp to Norixius",
+          "season": "Season 12b"
+        },
+        {
+          "date": "2025-08-27T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Player rewards: Ring of Acid Resistance, Stirring Dragon's Wrath Greatsword to Norixius",
+          "season": "Service Awards 2025"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2025-08-27",
+          "title": "DM Reward",
+          "perm_items": [
+            "Dragon's Wrath Greatsword",
+            "Ring of Acid Resistance"
+          ],
+          "level_plus": null,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2024-03-23",
+          "title": "DM Reward",
+          "perm_items": [
+            "The Sixth Sword"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2022-05-02",
+          "title": "Season 11b DM Reward (R)",
+          "perm_items": [
+            "Giant slayer greatsword"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2022-05-02",
+          "title": "Season 11b DM Reward (R)",
+          "perm_items": [
+            "Flametongue greatsword"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2022-04-20",
+          "title": "Season 11b DM Reward (R)",
+          "perm_items": [
+            "Dragon slayer greatsword"
+          ],
+          "level_plus": null,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Orakhar",
+      "dm_log": [
+        {
+          "date": "2020-04-29T00:00:00",
+          "code": "DDEX 2-10",
+          "name": "Cloaks and Shadows",
+          "item": "Winged Boots",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-10-03T00:00:00",
+          "code": "CCC-DES-01-06",
+          "name": "One Last Job",
+          "item": "Jeny's Special Helper (Broom of Flying), Black Shard Amulet, Charlatan's Die",
+          "allocation": "Item (Broom) to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-01-21T00:00:00",
+          "code": "CCC-CIC-15",
+          "name": "Den of the Dead Witch",
+          "item": "Necklace of Fireballs (6)",
+          "allocation": "Item to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-25T00:00:00",
+          "code": "CCC-BMG-23 PHLAN2-2",
+          "name": "Hatemaster",
+          "item": "Tyr's Blessing of Command",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-03-04T00:00:00",
+          "code": "CCC-BMG-24 PHLAN 2-3",
+          "name": "The Royal We",
+          "item": "Tyr's Blessing of Luck",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-03-27T00:00:00",
+          "code": "CCC-BMG-22 PHLAN2-1",
+          "name": "Demagogue",
+          "item": "Tyr's Blessing of the Mind",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-05-30T00:00:00",
+          "code": "CCC-BMG-MOON-6-2",
+          "name": "Troubled Visions",
+          "item": "Boots of Elvenkind, Moon Touched Short Sword",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-05-09T00:00:00",
+          "code": "DDAL05-05",
+          "name": "A Dish Best Served Cold",
+          "item": "Cloak of Displacement",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-07-16T00:00:00",
+          "code": "DDHC-OotA",
+          "name": "Chapter 15",
+          "item": "Scimitar of Speed",
+          "allocation": "Item to Orakhar",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-08-18T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Arrow-Catching Shield",
+          "allocation": "Level to Orakhar",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-08-27",
+          "title": "DM Reward x 4",
+          "perm_items": [],
+          "level_plus": 4,
+          "dtd_net": 80,
+          "notes": null
+        },
+        {
+          "date": "2021-08-27",
+          "title": "DM Reward",
+          "perm_items": [
+            "Broom of Flying"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-07-16",
+          "title": "DM Reward",
+          "perm_items": [
+            "Scimitar of Speed"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-06-11",
+          "title": "DM Rewards x 2",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 40,
+          "notes": null
+        },
+        {
+          "date": "2021-05-07",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2021-04-02",
+          "title": "DM Reward",
+          "perm_items": [
+            "Necklace of Fireballs (6 Beads)"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-03-26",
+          "title": "DM Reward (x2)",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Raguel",
+      "dm_log": [
+        {
+          "date": "2021-10-24T00:00:00",
+          "code": "HULB 4-1",
+          "name": "Whispers from the Deep",
+          "item": "Anstruth Harp",
+          "allocation": "Item (Harp) to Raguel",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-11-01T00:00:00",
+          "code": "CCC-QCC-2017",
+          "name": "Delusions of Grandeur, Dreams of Revenge",
+          "item": "Manual of Bodily Health",
+          "allocation": "Item (Manual) to Raguel",
+          "season": "preS11"
+        },
+        {
+          "date": "2024-07-06T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "8 levels to Raguel",
+          "season": "50th Anniversary Season B"
+        },
+        {
+          "date": "2024-08-28T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Player rewards: Vicious Maul + level to Raguel",
+          "season": "50th Anniversary Season B"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2024-11-20",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 8,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2024-11-20",
+          "title": "DM Reward",
+          "perm_items": [
+            "Manual of Bodily Health"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2024-11-20",
+          "title": "DM Reward",
+          "perm_items": [
+            "Anstruth Harp"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2024-11-20",
+          "title": "DM Reward",
+          "perm_items": [
+            "Vicious Lance"
+          ],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2024-11-20",
+          "title": "DM Reward",
+          "perm_items": [
+            "Spider Staff"
+          ],
+          "level_plus": 1,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Rolyn",
+      "dm_log": [
+        {
+          "date": "2023-03-15T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Gloves of Thievery + 10 DTD to Rolyn",
+          "season": "Season 12b"
+        },
+        {
+          "date": "2024-03-21T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Rogue's Mantle + 20 DTD to Rolyn",
+          "season": "50th Anniversary Season A"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2023-10-04",
+          "title": "DM Reward",
+          "perm_items": [
+            "Rogue's Mantle"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Sentient Hat",
+      "dm_log": [
+        {
+          "date": "2020-05-07T00:00:00",
+          "code": "DDAL 05-04",
+          "name": "In Dire Need",
+          "item": "Mithral Splint / Splint +1",
+          "allocation": "Item to (Splint +1) Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-08-12T00:00:00",
+          "code": "CCC-BLD 1-2",
+          "name": "Bleeding Gate: Amalgamation",
+          "item": "Winged Boots",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "NaT",
+          "code": "DDAL 10-00",
+          "name": "Ice Road Trackers",
+          "item": "",
+          "allocation": "Levels (x2) to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-10-10T00:00:00",
+          "code": "CCC-ELF-001",
+          "name": "Life's a Party",
+          "item": "Ring of Warmth",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-10-18T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Arrow-Catching Shield",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-11-05T00:00:00",
+          "code": "CCC-ELF-001",
+          "name": "Life's a Party",
+          "item": "Ring of Warmth",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-11-07T00:00:00",
+          "code": "CCC-DES-01-01",
+          "name": "Finding the Rabbit Hole",
+          "item": "FOWP - Ivory Goats",
+          "allocation": "Item to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-11-11T00:00:00",
+          "code": "CCC-GLIP-02-01",
+          "name": "Blue Scales",
+          "item": "Arrow-Catching Shield",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-11-21T00:00:00",
+          "code": "CCC-DES-01-02",
+          "name": "A Sanity Never Questioned",
+          "item": "Staff of Healing (Driftwood staff)",
+          "allocation": "Item to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-12-05T00:00:00",
+          "code": "CCC-DES-01-03",
+          "name": "A Question Never Asked",
+          "item": "Wand of Magic Missiles",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-12-19T00:00:00",
+          "code": "CCC-DES-01-04",
+          "name": "An Answer Never Offered",
+          "item": "Decanter of Endless Water",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-06T00:00:00",
+          "code": "CCC-DES-01-06",
+          "name": "One Last Job",
+          "item": "Broom of Flying, Charlatan's Die, Dark Shard Amulet",
+          "allocation": "Item to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-14T00:00:00",
+          "code": "DDAL10-03",
+          "name": "Divining Evil",
+          "item": "",
+          "allocation": "Level to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-23T00:00:00",
+          "code": "CCC-TRI-25",
+          "name": "Dead Men's Treasure",
+          "item": "Cli Lyre",
+          "allocation": "Item to Sentient Hat",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-03-20T00:00:00",
+          "code": "HULB 4-1",
+          "name": "Whispers from the Deep",
+          "item": "Anstruth Harp",
+          "allocation": "Item to Sentient Hat",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2021-03-27",
+          "title": "DM Reward",
+          "perm_items": [
+            "Broom of Flying"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward (x6)",
+          "perm_items": [],
+          "level_plus": 6,
+          "dtd_net": 120,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward (x2)",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 30,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward (x2)",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 40,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward",
+          "perm_items": [
+            "Cli Lyre"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward",
+          "perm_items": [
+            "Staff of Healing"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward",
+          "perm_items": [
+            "FOWP - Ivory Goats"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2021-02-24",
+          "title": "DM Reward",
+          "perm_items": [
+            "Splint +1"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Sookie Stackhouse",
+      "dm_log": [
+        {
+          "date": "2020-04-30T00:00:00",
+          "code": "CCC-BLD 1-1",
+          "name": "Bleeding Gate: Pandemonium",
+          "item": "Periapt of Wound Closure",
+          "allocation": "Level to Sookie Stackhouse",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-04-30T00:00:00",
+          "code": "CCC-BLD 1-2",
+          "name": "Bleeding Gate: Amalgamation",
+          "item": "Winged Boots",
+          "allocation": "Level to Sookie Stackhouse",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-05-02T00:00:00",
+          "code": "DDAL 05-04",
+          "name": "In Dire Need",
+          "item": "Mithral Splint / Splint +1",
+          "allocation": "Item to (Mithril Splint) Sookie Stackhouse",
+          "season": "preS11"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2020-06-20",
+          "title": "DM Reward x2",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2020-06-20",
+          "title": "DM Reward",
+          "perm_items": [
+            "Mithral Splintmail"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Squelch",
+      "dm_log": [
+        {
+          "date": "2022-04-27T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Dex Tome + 10k gp + level to Squelch",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-09-02T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Wis Tome + 30 DTD + level to Squelch",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2024-03-28T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Wraps of Unarmed Prowess + 10 DTD to Squelch",
+          "season": "50th Anniversary Season A"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2022-09-30",
+          "title": "DM Reward (12a VR)",
+          "perm_items": [
+            "Tome of Understanding"
+          ],
+          "level_plus": 1,
+          "dtd_net": 30,
+          "notes": null
+        },
+        {
+          "date": "2022-09-30",
+          "title": "DM Reward (11b VR)",
+          "perm_items": [
+            "Manual of Quickness of Action"
+          ],
+          "level_plus": 1,
+          "dtd_net": 0,
+          "notes": null
+        }
+      ]
+    },
+    {
+      "character": "Wobbly Bobbly",
+      "dm_log": [
+        {
+          "date": "2024-09-01T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "5 levels to Wobbly Bobbly",
+          "season": "50th Anniversary Season B"
+        }
+      ],
+      "char_log": []
+    },
+    {
+      "character": "Zandarax",
+      "dm_log": [
+        {
+          "date": "2020-03-28T00:00:00",
+          "code": "DDAL 09-01",
+          "name": "Escape from Elturguard",
+          "item": "Amulet of Proof Against Detection",
+          "allocation": "Levels to Zandarax (x2), Morty, S9 reward (Tressym) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-03-28T00:00:00",
+          "code": "DDAL 09-01",
+          "name": "Escape from Elturguard",
+          "item": "Amulet of Proof Against Detection",
+          "allocation": "Levels to Zandarax (x2), Morty, S9 reward (Tressym) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-04-04T00:00:00",
+          "code": "DDAL 09-02",
+          "name": "Stopped at the Gate",
+          "item": "Eyes of the Eagle",
+          "allocation": "S9 reward (Tressym) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-04-18T00:00:00",
+          "code": "DDAL 09-09",
+          "name": "Ruined Prospects",
+          "item": "Heward's Handy Haversack",
+          "allocation": "S9 reward (Tressym) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-04-21T00:00:00",
+          "code": "DDEX 2-10",
+          "name": "Cloaks and Shadows",
+          "item": "Winged Boots",
+          "allocation": "Item to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-07-22T00:00:00",
+          "code": "CCC-SALT-02-05",
+          "name": "The Darkness Never Forgets",
+          "item": "Cape of the Mountbank",
+          "allocation": "Item to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-08-22T00:00:00",
+          "code": "DDEP00-01",
+          "name": "The Red War (Tier 2)",
+          "item": "Boon of High Magic",
+          "allocation": "Boon to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-09-08T00:00:00",
+          "code": "DDHC-TYP",
+          "name": "Chapter 3 pt. 1",
+          "item": "Tloque's Battleaxe, Bracelet of Rock Magic, Bracers of Defense, Gloves of Missile Snaring, Longsword +1 (+2d6 vs plants), Ring of Animal Influence, Ring of Fire Resistance",
+          "allocation": "Item (battleax) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-09-19T00:00:00",
+          "code": "DDHC-TYP",
+          "name": "Chapter 3 pt. 1",
+          "item": "Bracelet of Rock Magic, +1 Dagger, +1 Longsword (plants)",
+          "allocation": "Item (bracelet) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2020-12-09T00:00:00",
+          "code": "CCC-TRI-28",
+          "name": "Siege of the Yellow Rose",
+          "item": "Robe of Stars (Cosmic Chausible)",
+          "allocation": "Item to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-12T00:00:00",
+          "code": "CCC-SEA-01-03",
+          "name": "Stargazing on the Albatross",
+          "item": "Bag of Devouring, Scroll of Simulacrum",
+          "allocation": "Item (Scroll) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-13T00:00:00",
+          "code": "CCC-SEA-01-03",
+          "name": "Stargazing on the Albatross",
+          "item": "Bag of Devouring, Scroll of Simulacrum",
+          "allocation": "Item (Scroll) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-02-13T00:00:00",
+          "code": "CCC-SEA-01-03",
+          "name": "Stargazing on the Albatross",
+          "item": "Bag of Devouring, Scroll of Simulacrum",
+          "allocation": "Item (Scroll) to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-10-01T00:00:00",
+          "code": "CCC-BLD-01-03",
+          "name": "Bleeding Gate: Lineage",
+          "item": "Stone of Controlling Earth Elementals, 190 gp",
+          "allocation": "Level to Zandarax",
+          "season": "preS11"
+        },
+        {
+          "date": "2021-11-02T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Nereid Shawl + 10 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-16T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Night Queen's eyes + 250 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-23T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Mariner's scale mail + 250 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-24T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Quiver of the centaurs + 250 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-25T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Lathai's saddle + 10 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-26T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Pixie winged boots + 10 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-27T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Darkthorn arrows (5) + 2500 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-11-28T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Faerie dragon's favor + 2500 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-12-01T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Hag's clawblade + 20 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-12-11T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Siren's caress + 20 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2021-12-14T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Blink Dog's Guide + 2500 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2022-02-15T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Sprite's Rescue + 20 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2022-02-16T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Daphnaie armor + 30 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2022-02-17T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Grif fiddle + 30 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2022-02-18T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Harengon's Freedom + 10,000 gp to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2022-02-19T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Wildmane's shoes + 30 DTD to Zandarax",
+          "season": "Season 11a"
+        },
+        {
+          "date": "2022-04-13T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Levels to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-05-28T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Emerald Pen + 10 DTD to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-05-29T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Periapt of Health + 10 DTD to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-06-01T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Bag of Tricks (Tan) + 10 DTD to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-06-16T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Dragon wing longbow + 20 DTD to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-06-16T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Gem of Seeing + 20 DTD to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-06-24T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Sapphire Buckler + 30 DTD to Zandarax",
+          "season": "Season 11b"
+        },
+        {
+          "date": "2022-09-02T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Pistol +1 + 10 DTD to Zandarax",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2022-09-03T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Spellwrought Tattoo (3rd level) + 10 DTD to Zandarax",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2022-09-03T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Wildspace Orrery + 10 DTD to Zandarax",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2022-09-04T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Armor of Radiant Resistant Halfplate + 20 DTD to Zandarax",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2022-09-10T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Mantle of Spell Resistance + 20 DTD to Zandarax",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2022-09-28T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Mace of Smiting + 20 DTD to Zandarax",
+          "season": "Season 12a"
+        },
+        {
+          "date": "2023-03-29T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Armor of Necrotic Restistance + 20 DTD to Zandarax",
+          "season": "Season 12b"
+        },
+        {
+          "date": "2023-05-03T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Kagonesti Forest Shroud + 20 DTD to Zandarax",
+          "season": "Season 12b"
+        },
+        {
+          "date": "2023-05-24T00:00:00",
+          "code": null,
+          "name": null,
+          "item": null,
+          "allocation": "Rod of Abosrption + 30 DTD to Zandarax",
+          "season": "Season 12b"
+        }
+      ],
+      "char_log": [
+        {
+          "date": "2023-10-04",
+          "title": "DM Reward",
+          "perm_items": [
+            "Armor of Necrotic Resistance"
+          ],
+          "level_plus": null,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2023-10-04",
+          "title": "DM Reward",
+          "perm_items": [
+            "Sixth Sword"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2023-10-04",
+          "title": "DM Reward",
+          "perm_items": [
+            "Kagonesti Forest Shroud"
+          ],
+          "level_plus": null,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2023-10-04",
+          "title": "DM Reward",
+          "perm_items": [
+            "Rod of Absorption"
+          ],
+          "level_plus": null,
+          "dtd_net": 30,
+          "notes": null
+        },
+        {
+          "date": "2023-01-20",
+          "title": "Season 12a DM Rewards (UC x 3, R x 3)",
+          "perm_items": [
+            "Pistol +1",
+            "Spellwrought Tattoo (3rd)",
+            "Wildspace Orrery",
+            "Armor of Radiant Resistant Halfplate",
+            "Mantle of Spell Resistance",
+            "Mace of Smiting"
+          ],
+          "level_plus": null,
+          "dtd_net": 90,
+          "notes": null
+        },
+        {
+          "date": "2023-01-20",
+          "title": "Season 11b DM Rewards (UC x 3, R x 2, VR x 1)",
+          "perm_items": [
+            "Emerald Pen",
+            "Periapt of Health",
+            "Bag of Tricks (tan)",
+            "Dragon Wing Longbow",
+            "Gem of Seeing",
+            "Sapphire Buckler"
+          ],
+          "level_plus": null,
+          "dtd_net": 100,
+          "notes": null
+        },
+        {
+          "date": "2022-06-08",
+          "title": "DM Reward",
+          "perm_items": [
+            "Szass Tam's Essence (Boon of High Magic)"
+          ],
+          "level_plus": 3,
+          "dtd_net": 0,
+          "notes": "Gained an additional 9th level spell slot"
+        },
+        {
+          "date": "2022-02-28",
+          "title": "Season 11 DM Reward (VR) x 4",
+          "perm_items": [
+            "Haregon's Freedom",
+            "Wildmane's shoes",
+            "Grig fiddle",
+            "Daphnaie armor"
+          ],
+          "level_plus": null,
+          "dtd_net": 90,
+          "notes": null
+        },
+        {
+          "date": "2022-02-28",
+          "title": "Season 11 DM Reward (UC) x 5",
+          "perm_items": [
+            "Nereid Shawl",
+            "Night Queen's Eyes",
+            "Mariner's scale mail",
+            "Quiver of the Centaurs",
+            "Lathai's saddle"
+          ],
+          "level_plus": null,
+          "dtd_net": 20,
+          "notes": null
+        },
+        {
+          "date": "2022-02-28",
+          "title": "Season 11 DM Reward (R) x 6",
+          "perm_items": [
+            "Darkthorn arrows (5)",
+            "Faerie dragon's favor",
+            "Hag's clawblade",
+            "Siren's caress",
+            "Blink Dog's Guide to Transversing the Feywild",
+            "Sprite's rescue"
+          ],
+          "level_plus": null,
+          "dtd_net": 60,
+          "notes": null
+        },
+        {
+          "date": "2021-11-21",
+          "title": "Season 11 DM Reward UC",
+          "perm_items": [
+            "Winged Boots"
+          ],
+          "level_plus": null,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2021-10-26",
+          "title": "DM Reward",
+          "perm_items": [],
+          "level_plus": 1,
+          "dtd_net": 10,
+          "notes": null
+        },
+        {
+          "date": "2020-12-10",
+          "title": "DM Reward",
+          "perm_items": [
+            "Cosmic Chausible"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-10-17",
+          "title": "DM Reward",
+          "perm_items": [
+            "Cape of the Mountebank"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-09-23",
+          "title": "DM Reward",
+          "perm_items": [
+            "Bracelet of Rock Magic"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-09-11",
+          "title": "DM Reward S9 (x3)",
+          "perm_items": [],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": "Can summon a Tressym familiar"
+        },
+        {
+          "date": "2020-09-08",
+          "title": "DM Reward",
+          "perm_items": [
+            "Winged Boots"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-09-07",
+          "title": "DM Reward",
+          "perm_items": [
+            "Tloque's Battleaxe"
+          ],
+          "level_plus": null,
+          "dtd_net": 0,
+          "notes": null
+        },
+        {
+          "date": "2020-07-16",
+          "title": "DM Reward (x2)",
+          "perm_items": [],
+          "level_plus": 2,
+          "dtd_net": 20,
+          "notes": null
+        }
+      ]
+    }
+  ],
+  "missing": {
+    "Steve*": [
+      {
+        "date": "2020-09-08T00:00:00",
+        "code": "CCC-DES-01-01",
+        "name": "Finding the Rabbit Hole",
+        "tier": 2,
+        "levels_plus": 1,
+        "levels_minus": 1,
+        "item": "FOWP - Ivory Goats",
+        "allocation": "Level to Steve*",
+        "location": "Gateway"
+      },
+      {
+        "date": "2020-09-18T00:00:00",
+        "code": "Playtest",
+        "name": "Tier 1 w/ Jon K.",
+        "tier": 1,
+        "levels_plus": 1,
+        "levels_minus": 1,
+        "item": "",
+        "allocation": "Level to Steve*",
+        "location": "private"
+      }
+    ],
+    "Sir Smol": [
+      {
+        "date": "2021-05-29T00:00:00",
+        "code": "DDAL-DRWEP02",
+        "name": "Wings of Death",
+        "tier": 3,
+        "levels_plus": 1,
+        "levels_minus": 1,
+        "item": "Bracers of Defense",
+        "allocation": "Item to Sir Smol",
+        "location": "GameX"
+      },
+      {
+        "date": "2021-09-04T00:00:00",
+        "code": "CCC-BLD-01-03",
+        "name": "Bleeding Gate: Lineage",
+        "tier": 2,
+        "levels_plus": 1,
+        "levels_minus": 1,
+        "item": "Stone of Controlling Earth Elementals",
+        "allocation": "Level to Sir Smol",
+        "location": "Gateway"
+      },
+      {
+        "date": "2021-09-29T00:00:00",
+        "code": "DDHC-TOA-9",
+        "name": "Ruins of Matolo",
+        "tier": 2,
+        "levels_plus": 1,
+        "levels_minus": 1,
+        "item": "Marvelous Pigments, Bronze Griffon, +1 Scimitar, +1 Spear (Sentient), +1 Greataxe (Sentient)",
+        "allocation": "Item (Pigments) to Sir Smol",
+        "location": "private"
+      }
+    ]
+  }
+}

--- a/analysis/dm_reward_verification.md
+++ b/analysis/dm_reward_verification.md
@@ -1,0 +1,385 @@
+# DM Reward Cross-Check
+
+This report lists each character that receives allocations in the DM log alongside the corresponding DM Reward entries recorded on their character sheet.
+
+## Agatha
+
+**DM log allocations**
+- 2024-09-11T00:00:00: 3 levels to Agatha (50th Anniversary Season B)
+- 2025-04-25T00:00:00: Ring of Invisibility + 40 DTD to Agatha (Service Awards 2025)
+
+**Character log DM rewards**
+- 2025-05-14: DM Reward | levels: — | items: Ring of Invisibility | DTD Δ: 40
+- 2024-09-11: DM Reward | levels: 3 | items: — | DTD Δ: 0
+
+## Anfer
+
+**DM log allocations**
+- 2021-02-04T00:00:00: Level to Anfer | item: Cape of Billowing (CCC-MCX-01-02)
+
+**Character log DM rewards**
+- 2021-02-24: DM Reward | levels: 1 | items: — | DTD Δ: 20
+
+## Arvistan Brightwave
+
+**DM log allocations**
+- 2025-05-28T00:00:00: Player rewards: Arcane Grimoire +3 and Blessing of Protection to Arvistan (Service Awards 2025)
+
+**Character log DM rewards**
+- 2025-05-28: DM Reward | levels: — | items: Arcane Grimoire +3, Blessing of Protection | DTD Δ: 10
+- 2020-11-01: DM Reward | levels: 1 | items: — | DTD Δ: 20
+
+## Buckley
+
+**DM log allocations**
+- 2020-03-03T00:00:00: Levels to Darrendrian (x2), Morty, Buckley | item: Amulet of Proof Against Detection (DDAL 09-01)
+
+**Character log DM rewards**
+- 2020-03-03: DM Reward | levels: 1 | items: — | DTD Δ: 10
+
+## Chef Ture
+
+**DM log allocations**
+- 2024-09-01T00:00:00: Boomerang Shield + 10 DTD to Chef Ture (50th Anniversary Season B)
+- 2024-09-01T00:00:00: Rare reward (Flametongue Warhammer) + 2500gp to Chef Ture (50th Anniversary Season B)
+
+**Character log DM rewards**
+- None: DM Reward x 2 | levels: 1 | items: Boomerang Shield, Flametongue Warhammer | DTD Δ: 10
+
+## Creature X-12
+
+**DM log allocations**
+- 2020-09-08T00:00:00: Hat of Disuise to Creature X-12 | item: Wand of Lightning Bolts, Hat of Disguise, Eagle Whistle, Dagger +1 (broken), Dagger +1, Mace +1 (broken), Stone of Ill Luck (DDHC-TYP)
+- 2022-07-03T00:00:00: Level to Creature X-12 (Season 11b)
+
+**Character log DM rewards**
+- 2023-07-06: DM Reward (x2) | levels: 1 | items: Hat of Disguise | DTD Δ: 0
+
+## Darrendrian
+
+**DM log allocations**
+- 2020-03-03T00:00:00: Levels to Darrendrian (x2), Morty, Buckley | item: Amulet of Proof Against Detection (DDAL 09-01)
+- 2020-06-20T00:00:00: Item to Darrendrian | item: Cape of the Mountbank (CCC-SALT-02-05)
+- 2020-09-19T00:00:00: Item to Darrendrian | item: Wand of Lightning Bolts, Hat of Disguise, Eagle Whistle (DDHC-TYP)
+
+**Character log DM rewards**
+- 2021-10-03: DM Reward | levels: — | items: Wand of Lightning Bolts | DTD Δ: 0
+- 2020-06-26: DM Reward | levels: — | items: Cape of the Mountbank | DTD Δ: 0
+- 2020-03-06: DM Reward | levels: — | items: — | DTD Δ: 20
+- 2020-03-03: DM Reward | levels: — | items: — | DTD Δ: 20
+
+## Dolroruuk
+
+**DM log allocations**
+- 2021-05-25T00:00:00: Level to Dolroruuk | item: Boots of Elvenkind, Moon Touched Rapier (CCC-BMG-MOON-6-2)
+- 2021-05-31T00:00:00: Level to Dolroruuk | item: Javeline of Lightning, Horn of Silent Alarm (CCC-BMG-MOON-6-3)
+- 2021-09-15T00:00:00: Level to Dolroruuk | item: Staff of Healing (Driftwood staff) (CCC-DES-01-02)
+
+**Character log DM rewards**
+- None: DM Reward x 3 | levels: 3 | items: — | DTD Δ: 30
+
+## Gnat
+
+**DM log allocations**
+- 2021-09-03T00:00:00: Item to Gnat | item: Amulet of Health, Mariner's Studded Leather (DRW-09)
+- 2028-07-14T00:00:00: Rare reward (Vicious Glavie) to Gnat + 2500 gp (50th Anniversary Season B)
+
+**Character log DM rewards**
+- 2021-09-29: DM Reward | levels: 1 | items: — | DTD Δ: 10
+- 2021-09-29: DM Reward | levels: — | items: Marvelous Pigments | DTD Δ: 0
+- 2021-09-29: DM Reward | levels: — | items: Bracers of Defense | DTD Δ: 0
+- None: DM Reward | levels: — | items: Amulet of Health | DTD Δ: 0
+- None: DM Reward | levels: — | items: Vicious Glaive | DTD Δ: 0
+
+## Goblert Godfrey
+
+**DM log allocations**
+- 2021-10-19T00:00:00: Item to (Pigments) to Goblert | item: Marvelous Pigments, Bronze Griffon, +1 Scimitar, 2310 gp (DDHC-TOA-9)
+
+**Character log DM rewards**
+- 2022-01-15: DM Reward | levels: — | items: Nolzur's Pigments | DTD Δ: 0
+
+## Leonardo
+
+**DM log allocations**
+- 2020-06-06T00:00:00: Item to Leonardo | item: Bracers of Defense (CCC-CIC-10)
+
+**Character log DM rewards**
+- 2020-07-19: DM Reward | levels: — | items: Bracers of Defense | DTD Δ: 0
+
+## Lorien
+
+**DM log allocations**
+- 2020-05-16T00:00:00: Level to Lorien | item: Periapt of Health (DDAL 09-04)
+- 2020-06-25T00:00:00: Level to Lorien | item: Ring of Warmth (CCC-ELF-001)
+- 2020-07-04T00:00:00: Level to Lorien | item: Arrow-Catching Shield (CCC-GLIP-02-01)
+
+**Character log DM rewards**
+- 2020-07-13: DM Rewards x3 | levels: 3 | items: — | DTD Δ: 60
+
+## Lyrielle
+
+**DM log allocations**
+- 2021-05-09T00:00:00: Item to Lyrielle | item: Fey Cloak of Protection (CCC-BMG-MOON6-3)
+- 2021-05-19T00:00:00: Item to Lyrielle | item: Necklace of Fireballs (6) (CCC-CIC-15)
+- 2021-06-23T00:00:00: Level to Lyrielle | item: Ring of Warmth (CCC-ELF-001)
+- 2021-06-26T00:00:00: Level to Lyrielle | item: Arrow-Catching Shield (CCC-GLIP-02-01)
+- 2021-06-27T00:00:00: Level to Lyrielle | item: Javeline of Lightning, Horn of Silent Alarm (CCC-BMG-MOON-6-3)
+- 2021-06-30T00:00:00: Level to Lyrielle | item: Arrow-Catching Shield (CCC-GLIP-02-01)
+- 2021-07-12T00:00:00: Level to Lyrielle (CCC-MCX-01-02)
+- 2021-07-28T00:00:00: Level to Lyrielle | item: Boots of the Winterlands, Pole of Angling (DC-PoA-DCAF01)
+- 2022-07-08T00:00:00: Levels to Lyrielle (Season 11b)
+
+**Character log DM rewards**
+- 2022-07-04: DM Reward | levels: 6 | items: — | DTD Δ: 0
+- 2021-09-04: DM Reward x 2 | levels: 2 | items: — | DTD Δ: 40
+- 2021-08-27: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2021-07-15: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2021-07-15: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2021-07-15: DM Reward | levels: — | items: Fey Cloak of Protection | DTD Δ: 0
+- 2021-07-06: DM Reward x 3 | levels: 3 | items: — | DTD Δ: 30
+- 2021-07-06: DM Reward | levels: — | items: Necklace of Fireballs | DTD Δ: 0
+
+## Madam Renata
+
+**DM log allocations**
+- 2021-05-28T00:00:00: Level to Madam Renata | item: Javeline of Lightning, Horn of Silent Alarm (CCC-BMG-MOON-6-3)
+- 2021-09-03T00:00:00: Item to Madam Renata | item: Winged Boots (DDEX02-10)
+- 2021-09-08T00:00:00: Level to Madam Renata | item: FOWP - Ivory Goats (CCC-DES-01-01)
+
+**Character log DM rewards**
+- 2021-09-24: DM Reward x 3 | levels: 3 | items: — | DTD Δ: 30
+- 2021-09-24: DM Reward | levels: — | items: Winged Boots | DTD Δ: 0
+
+## Morty
+
+**DM log allocations**
+- 2020-03-03T00:00:00: Levels to Darrendrian (x2), Morty, Buckley | item: Amulet of Proof Against Detection (DDAL 09-01)
+- 2020-03-28T00:00:00: Levels to Zandarax (x2), Morty, S9 reward (Tressym) to Zandarax | item: Amulet of Proof Against Detection (DDAL 09-01)
+- 2020-06-18T00:00:00: Level to Morty | item: Bracers of Defense (CCC-CIC-10)
+- 2020-08-06T00:00:00: Level to Morty | item: Ring of Warmth (CCC-GLIP-02-01)
+
+**Character log DM rewards**
+- 2020-08-08: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2020-08-08: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2020-08-08: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2020-03-25: DM Reward | levels: 1 | items: — | DTD Δ: 10
+
+## Noraggen
+
+**DM log allocations**
+- 2020-05-21T00:00:00: Level to Noraggen | item: Periapt of Health (DDAL 09-04)
+- 2020-06-05T00:00:00: Level to Noraggen (Playtest)
+- 2020-08-12T00:00:00: Level to Noraggen | item: Periapt of Wound Closure (CCC-BLD 1-1)
+- 2020-08-15T00:00:00: Level to Noraggen | item: Bracers of Defense (CCC-CIC-10)
+- 2020-11-15T00:00:00: Item (Battleaxe) to Noraggen | item: Tloque's Battleaxe, Bracelet of Rock Magic, Eagle Whistle (DDHC-TYP)
+- 2021-02-18T00:00:00: Level to Noraggen | item: Tyr's Blessing of the Mind (CCC-BMG-22 PHLAN2-1)
+
+**Character log DM rewards**
+- 2021-04-01: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2020-11-18: DM Reward (x4) | levels: 4 | items: — | DTD Δ: 40
+- 2020-11-18: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2020-11-18: DM Reward | levels: — | items: Tloque's Battleaxe | DTD Δ: 0
+
+## Norixius
+
+**DM log allocations**
+- 2022-03-07T00:00:00: Dragon slayer greatsword + 20 DTD to Norixius (Season 11b)
+- 2022-03-09T00:00:00: Giant slayer greatsword + 2500 gp to Norixius (Season 11b)
+- 2022-04-07T00:00:00: Flametongue greatsword + 2500 gp to Norixius (Season 11b)
+- 2023-04-26T00:00:00: Sixth Sword + 2500gp to Norixius (Season 12b)
+- 2025-08-27T00:00:00: Player rewards: Ring of Acid Resistance, Stirring Dragon's Wrath Greatsword to Norixius (Service Awards 2025)
+
+**Character log DM rewards**
+- 2025-08-27: DM Reward | levels: — | items: Dragon's Wrath Greatsword, Ring of Acid Resistance | DTD Δ: 10
+- 2024-03-23: DM Reward | levels: — | items: The Sixth Sword | DTD Δ: 0
+- 2022-05-02: Season 11b DM Reward (R) | levels: — | items: Giant slayer greatsword | DTD Δ: 0
+- 2022-05-02: Season 11b DM Reward (R) | levels: — | items: Flametongue greatsword | DTD Δ: 0
+- 2022-04-20: Season 11b DM Reward (R) | levels: — | items: Dragon slayer greatsword | DTD Δ: 20
+
+## Orakhar
+
+**DM log allocations**
+- 2020-04-29T00:00:00: Level to Orakhar | item: Winged Boots (DDEX 2-10)
+- 2020-10-03T00:00:00: Item (Broom) to Orakhar | item: Jeny's Special Helper (Broom of Flying), Black Shard Amulet, Charlatan's Die (CCC-DES-01-06)
+- 2021-01-21T00:00:00: Item to Orakhar | item: Necklace of Fireballs (6) (CCC-CIC-15)
+- 2021-02-25T00:00:00: Level to Orakhar | item: Tyr's Blessing of Command (CCC-BMG-23 PHLAN2-2)
+- 2021-03-04T00:00:00: Level to Orakhar | item: Tyr's Blessing of Luck (CCC-BMG-24 PHLAN 2-3)
+- 2021-03-27T00:00:00: Level to Orakhar | item: Tyr's Blessing of the Mind (CCC-BMG-22 PHLAN2-1)
+- 2021-05-30T00:00:00: Level to Orakhar | item: Boots of Elvenkind, Moon Touched Short Sword (CCC-BMG-MOON-6-2)
+- 2021-05-09T00:00:00: Level to Orakhar | item: Cloak of Displacement (DDAL05-05)
+- 2021-07-16T00:00:00: Item to Orakhar | item: Scimitar of Speed (DDHC-OotA)
+- 2021-08-18T00:00:00: Level to Orakhar | item: Arrow-Catching Shield (CCC-GLIP-02-01)
+
+**Character log DM rewards**
+- 2021-08-27: DM Reward x 4 | levels: 4 | items: — | DTD Δ: 80
+- 2021-08-27: DM Reward | levels: — | items: Broom of Flying | DTD Δ: 0
+- 2021-07-16: DM Reward | levels: — | items: Scimitar of Speed | DTD Δ: 0
+- 2021-06-11: DM Rewards x 2 | levels: 2 | items: — | DTD Δ: 40
+- 2021-05-07: DM Reward | levels: 1 | items: — | DTD Δ: 20
+- 2021-04-02: DM Reward | levels: — | items: Necklace of Fireballs (6 Beads) | DTD Δ: 0
+- 2021-03-26: DM Reward (x2) | levels: 2 | items: — | DTD Δ: 20
+
+## Raguel
+
+**DM log allocations**
+- 2021-10-24T00:00:00: Item (Harp) to Raguel | item: Anstruth Harp (HULB 4-1)
+- 2021-11-01T00:00:00: Item (Manual) to Raguel | item: Manual of Bodily Health (CCC-QCC-2017)
+- 2024-07-06T00:00:00: 8 levels to Raguel (50th Anniversary Season B)
+- 2024-08-28T00:00:00: Player rewards: Vicious Maul + level to Raguel (50th Anniversary Season B)
+
+**Character log DM rewards**
+- 2024-11-20: DM Reward | levels: 8 | items: — | DTD Δ: 0
+- 2024-11-20: DM Reward | levels: — | items: Manual of Bodily Health | DTD Δ: 0
+- 2024-11-20: DM Reward | levels: — | items: Anstruth Harp | DTD Δ: 0
+- 2024-11-20: DM Reward | levels: 1 | items: Vicious Lance | DTD Δ: 20
+- 2024-11-20: DM Reward | levels: 1 | items: Spider Staff | DTD Δ: 20
+
+## Rolyn
+
+**DM log allocations**
+- 2023-03-15T00:00:00: Gloves of Thievery + 10 DTD to Rolyn (Season 12b)
+- 2024-03-21T00:00:00: Rogue's Mantle + 20 DTD to Rolyn (50th Anniversary Season A)
+
+**Character log DM rewards**
+- 2023-10-04: DM Reward | levels: — | items: Rogue's Mantle | DTD Δ: 0
+
+## Sentient Hat
+
+**DM log allocations**
+- 2020-05-07T00:00:00: Item to (Splint +1) Sentient Hat | item: Mithral Splint / Splint +1 (DDAL 05-04)
+- 2020-08-12T00:00:00: Level to Sentient Hat | item: Winged Boots (CCC-BLD 1-2)
+- NaT: Levels (x2) to Sentient Hat (DDAL 10-00)
+- 2020-10-10T00:00:00: Level to Sentient Hat | item: Ring of Warmth (CCC-ELF-001)
+- 2020-10-18T00:00:00: Level to Sentient Hat | item: Arrow-Catching Shield (CCC-GLIP-02-01)
+- 2020-11-05T00:00:00: Level to Sentient Hat | item: Ring of Warmth (CCC-ELF-001)
+- 2020-11-07T00:00:00: Item to Sentient Hat | item: FOWP - Ivory Goats (CCC-DES-01-01)
+- 2020-11-11T00:00:00: Level to Sentient Hat | item: Arrow-Catching Shield (CCC-GLIP-02-01)
+- 2020-11-21T00:00:00: Item to Sentient Hat | item: Staff of Healing (Driftwood staff) (CCC-DES-01-02)
+- 2020-12-05T00:00:00: Level to Sentient Hat | item: Wand of Magic Missiles (CCC-DES-01-03)
+- 2020-12-19T00:00:00: Level to Sentient Hat | item: Decanter of Endless Water (CCC-DES-01-04)
+- 2021-02-06T00:00:00: Item to Sentient Hat | item: Broom of Flying, Charlatan's Die, Dark Shard Amulet (CCC-DES-01-06)
+- 2021-02-14T00:00:00: Level to Sentient Hat (DDAL10-03)
+- 2021-02-23T00:00:00: Item to Sentient Hat | item: Cli Lyre (CCC-TRI-25)
+- 2021-03-20T00:00:00: Item to Sentient Hat | item: Anstruth Harp (HULB 4-1)
+
+**Character log DM rewards**
+- 2021-03-27: DM Reward | levels: — | items: Broom of Flying | DTD Δ: 0
+- 2021-02-24: DM Reward (x6) | levels: 6 | items: — | DTD Δ: 120
+- 2021-02-24: DM Reward (x2) | levels: 2 | items: — | DTD Δ: 30
+- 2021-02-24: DM Reward (x2) | levels: 2 | items: — | DTD Δ: 40
+- 2021-02-24: DM Reward | levels: — | items: Cli Lyre | DTD Δ: 0
+- 2021-02-24: DM Reward | levels: — | items: Staff of Healing | DTD Δ: 0
+- 2021-02-24: DM Reward | levels: — | items: FOWP - Ivory Goats | DTD Δ: 0
+- 2021-02-24: DM Reward | levels: — | items: Splint +1 | DTD Δ: 0
+
+## Sookie Stackhouse
+
+**DM log allocations**
+- 2020-04-30T00:00:00: Level to Sookie Stackhouse | item: Periapt of Wound Closure (CCC-BLD 1-1)
+- 2020-04-30T00:00:00: Level to Sookie Stackhouse | item: Winged Boots (CCC-BLD 1-2)
+- 2020-05-02T00:00:00: Item to (Mithril Splint) Sookie Stackhouse | item: Mithral Splint / Splint +1 (DDAL 05-04)
+
+**Character log DM rewards**
+- 2020-06-20: DM Reward x2 | levels: 2 | items: — | DTD Δ: 20
+- 2020-06-20: DM Reward | levels: — | items: Mithral Splintmail | DTD Δ: 0
+
+## Squelch
+
+**DM log allocations**
+- 2022-04-27T00:00:00: Dex Tome + 10k gp + level to Squelch (Season 11b)
+- 2022-09-02T00:00:00: Wis Tome + 30 DTD + level to Squelch (Season 12a)
+- 2024-03-28T00:00:00: Wraps of Unarmed Prowess + 10 DTD to Squelch (50th Anniversary Season A)
+
+**Character log DM rewards**
+- 2022-09-30: DM Reward (12a VR) | levels: 1 | items: Tome of Understanding | DTD Δ: 30
+- 2022-09-30: DM Reward (11b VR) | levels: 1 | items: Manual of Quickness of Action | DTD Δ: 0
+
+## Wobbly Bobbly
+
+**DM log allocations**
+- 2024-09-01T00:00:00: 5 levels to Wobbly Bobbly (50th Anniversary Season B)
+
+**Character log DM rewards**
+- _No DM Reward entries recorded_
+
+## Zandarax
+
+**DM log allocations**
+- 2020-03-28T00:00:00: Levels to Zandarax (x2), Morty, S9 reward (Tressym) to Zandarax | item: Amulet of Proof Against Detection (DDAL 09-01)
+- 2020-03-28T00:00:00: Levels to Zandarax (x2), Morty, S9 reward (Tressym) to Zandarax | item: Amulet of Proof Against Detection (DDAL 09-01)
+- 2020-04-04T00:00:00: S9 reward (Tressym) to Zandarax | item: Eyes of the Eagle (DDAL 09-02)
+- 2020-04-18T00:00:00: S9 reward (Tressym) to Zandarax | item: Heward's Handy Haversack (DDAL 09-09)
+- 2020-04-21T00:00:00: Item to Zandarax | item: Winged Boots (DDEX 2-10)
+- 2020-07-22T00:00:00: Item to Zandarax | item: Cape of the Mountbank (CCC-SALT-02-05)
+- 2020-08-22T00:00:00: Boon to Zandarax | item: Boon of High Magic (DDEP00-01)
+- 2020-09-08T00:00:00: Item (battleax) to Zandarax | item: Tloque's Battleaxe, Bracelet of Rock Magic, Bracers of Defense, Gloves of Missile Snaring, Longsword +1 (+2d6 vs plants), Ring of Animal Influence, Ring of Fire Resistance (DDHC-TYP)
+- 2020-09-19T00:00:00: Item (bracelet) to Zandarax | item: Bracelet of Rock Magic, +1 Dagger, +1 Longsword (plants) (DDHC-TYP)
+- 2020-12-09T00:00:00: Item to Zandarax | item: Robe of Stars (Cosmic Chausible) (CCC-TRI-28)
+- 2021-02-12T00:00:00: Item (Scroll) to Zandarax | item: Bag of Devouring, Scroll of Simulacrum (CCC-SEA-01-03)
+- 2021-02-13T00:00:00: Item (Scroll) to Zandarax | item: Bag of Devouring, Scroll of Simulacrum (CCC-SEA-01-03)
+- 2021-02-13T00:00:00: Item (Scroll) to Zandarax | item: Bag of Devouring, Scroll of Simulacrum (CCC-SEA-01-03)
+- 2021-10-01T00:00:00: Level to Zandarax | item: Stone of Controlling Earth Elementals, 190 gp (CCC-BLD-01-03)
+- 2021-11-02T00:00:00: Nereid Shawl + 10 DTD to Zandarax (Season 11a)
+- 2021-11-16T00:00:00: Night Queen's eyes + 250 gp to Zandarax (Season 11a)
+- 2021-11-23T00:00:00: Mariner's scale mail + 250 gp to Zandarax (Season 11a)
+- 2021-11-24T00:00:00: Quiver of the centaurs + 250 gp to Zandarax (Season 11a)
+- 2021-11-25T00:00:00: Lathai's saddle + 10 DTD to Zandarax (Season 11a)
+- 2021-11-26T00:00:00: Pixie winged boots + 10 DTD to Zandarax (Season 11a)
+- 2021-11-27T00:00:00: Darkthorn arrows (5) + 2500 gp to Zandarax (Season 11a)
+- 2021-11-28T00:00:00: Faerie dragon's favor + 2500 gp to Zandarax (Season 11a)
+- 2021-12-01T00:00:00: Hag's clawblade + 20 DTD to Zandarax (Season 11a)
+- 2021-12-11T00:00:00: Siren's caress + 20 DTD to Zandarax (Season 11a)
+- 2021-12-14T00:00:00: Blink Dog's Guide + 2500 gp to Zandarax (Season 11a)
+- 2022-02-15T00:00:00: Sprite's Rescue + 20 DTD to Zandarax (Season 11a)
+- 2022-02-16T00:00:00: Daphnaie armor + 30 DTD to Zandarax (Season 11a)
+- 2022-02-17T00:00:00: Grif fiddle + 30 DTD to Zandarax (Season 11a)
+- 2022-02-18T00:00:00: Harengon's Freedom + 10,000 gp to Zandarax (Season 11a)
+- 2022-02-19T00:00:00: Wildmane's shoes + 30 DTD to Zandarax (Season 11a)
+- 2022-04-13T00:00:00: Levels to Zandarax (Season 11b)
+- 2022-05-28T00:00:00: Emerald Pen + 10 DTD to Zandarax (Season 11b)
+- 2022-05-29T00:00:00: Periapt of Health + 10 DTD to Zandarax (Season 11b)
+- 2022-06-01T00:00:00: Bag of Tricks (Tan) + 10 DTD to Zandarax (Season 11b)
+- 2022-06-16T00:00:00: Dragon wing longbow + 20 DTD to Zandarax (Season 11b)
+- 2022-06-16T00:00:00: Gem of Seeing + 20 DTD to Zandarax (Season 11b)
+- 2022-06-24T00:00:00: Sapphire Buckler + 30 DTD to Zandarax (Season 11b)
+- 2022-09-02T00:00:00: Pistol +1 + 10 DTD to Zandarax (Season 12a)
+- 2022-09-03T00:00:00: Spellwrought Tattoo (3rd level) + 10 DTD to Zandarax (Season 12a)
+- 2022-09-03T00:00:00: Wildspace Orrery + 10 DTD to Zandarax (Season 12a)
+- 2022-09-04T00:00:00: Armor of Radiant Resistant Halfplate + 20 DTD to Zandarax (Season 12a)
+- 2022-09-10T00:00:00: Mantle of Spell Resistance + 20 DTD to Zandarax (Season 12a)
+- 2022-09-28T00:00:00: Mace of Smiting + 20 DTD to Zandarax (Season 12a)
+- 2023-03-29T00:00:00: Armor of Necrotic Restistance + 20 DTD to Zandarax (Season 12b)
+- 2023-05-03T00:00:00: Kagonesti Forest Shroud + 20 DTD to Zandarax (Season 12b)
+- 2023-05-24T00:00:00: Rod of Abosrption + 30 DTD to Zandarax (Season 12b)
+
+**Character log DM rewards**
+- 2023-10-04: DM Reward | levels: — | items: Armor of Necrotic Resistance | DTD Δ: 10
+- 2023-10-04: DM Reward | levels: — | items: Sixth Sword | DTD Δ: 0
+- 2023-10-04: DM Reward | levels: — | items: Kagonesti Forest Shroud | DTD Δ: 10
+- 2023-10-04: DM Reward | levels: — | items: Rod of Absorption | DTD Δ: 30
+- 2023-01-20: Season 12a DM Rewards (UC x 3, R x 3) | levels: — | items: Pistol +1, Spellwrought Tattoo (3rd), Wildspace Orrery, Armor of Radiant Resistant Halfplate, Mantle of Spell Resistance, Mace of Smiting | DTD Δ: 90
+- 2023-01-20: Season 11b DM Rewards (UC x 3, R x 2, VR x 1) | levels: — | items: Emerald Pen, Periapt of Health, Bag of Tricks (tan), Dragon Wing Longbow, Gem of Seeing, Sapphire Buckler | DTD Δ: 100
+- 2022-06-08: DM Reward | levels: 3 | items: Szass Tam's Essence (Boon of High Magic) | DTD Δ: 0
+- 2022-02-28: Season 11 DM Reward (VR) x 4 | levels: — | items: Haregon's Freedom, Wildmane's shoes, Grig fiddle, Daphnaie armor | DTD Δ: 90
+- 2022-02-28: Season 11 DM Reward (UC) x 5 | levels: — | items: Nereid Shawl, Night Queen's Eyes, Mariner's scale mail, Quiver of the Centaurs, Lathai's saddle | DTD Δ: 20
+- 2022-02-28: Season 11 DM Reward (R) x 6 | levels: — | items: Darkthorn arrows (5), Faerie dragon's favor, Hag's clawblade, Siren's caress, Blink Dog's Guide to Transversing the Feywild, Sprite's rescue | DTD Δ: 60
+- 2021-11-21: Season 11 DM Reward UC | levels: — | items: Winged Boots | DTD Δ: 10
+- 2021-10-26: DM Reward | levels: 1 | items: — | DTD Δ: 10
+- 2020-12-10: DM Reward | levels: — | items: Cosmic Chausible | DTD Δ: 0
+- 2020-10-17: DM Reward | levels: — | items: Cape of the Mountebank | DTD Δ: 0
+- 2020-09-23: DM Reward | levels: — | items: Bracelet of Rock Magic | DTD Δ: 0
+- 2020-09-11: DM Reward S9 (x3) | levels: — | items: — | DTD Δ: 0
+- 2020-09-08: DM Reward | levels: — | items: Winged Boots | DTD Δ: 0
+- 2020-09-07: DM Reward | levels: — | items: Tloque's Battleaxe | DTD Δ: 0
+- 2020-07-16: DM Reward (x2) | levels: 2 | items: — | DTD Δ: 20
+
+## Orphan allocations
+
+- Steve*
+  - 2020-09-08T00:00:00: Level to Steve* (CCC-DES-01-01)
+  - 2020-09-18T00:00:00: Level to Steve* (Playtest)
+- Sir Smol
+  - 2021-05-29T00:00:00: Item to Sir Smol (DDAL-DRWEP02)
+  - 2021-09-04T00:00:00: Level to Sir Smol (CCC-BLD-01-03)
+  - 2021-09-29T00:00:00: Item (Pigments) to Sir Smol (DDHC-TOA-9)

--- a/index.html
+++ b/index.html
@@ -42,12 +42,6 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 
 /* Toolbar */
 .toolbar{margin-top:10px;display:flex;gap:10px;flex-wrap:wrap}
-.dm-actions{position:relative;display:flex;align-items:center}
-.dm-actions .btn{display:inline-flex;align-items:center;gap:8px}
-.dm-menu{position:absolute;top:calc(100% + 6px);left:0;display:flex;flex-direction:column;min-width:180px;padding:6px 0;border-radius:12px;background:#fff;box-shadow:var(--shadow2);border:1px solid var(--border);z-index:40}
-.dm-menu[hidden]{display:none}
-.dm-menu-item{padding:8px 14px;text-align:left;background:none;border:none;font:inherit;color:var(--ink);cursor:pointer;transition:background var(--dur) var(--ease),color var(--dur) var(--ease)}
-.dm-menu-item:hover,.dm-menu-item:focus{background:#eef4ff;color:var(--primary);outline:none}
 .select,.btn,.search input{border:1px solid var(--border);background:#fff;border-radius:12px;padding:10px 12px;font-weight:600;box-shadow:var(--shadow1)}
 .btn{cursor:pointer;transition:transform var(--dur) var(--ease),box-shadow var(--dur) var(--ease)}
 .btn:hover{transform:translateY(-1px);box-shadow:var(--shadow2)}
@@ -246,6 +240,7 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 
 body.modal-open{overflow:hidden;}
 body.modal-open #addCard{display:none;}
+body.modal-open #addCardMenu{display:none;}
 
 #addCard{
   position:fixed;
@@ -269,6 +264,11 @@ body.modal-open #addCard{display:none;}
 #addCard:hover{transform:translateY(-2px);box-shadow:0 24px 40px rgba(255,61,113,.45)}
 #addCard:focus-visible{outline:3px solid rgba(255,61,113,.4);outline-offset:4px}
 .toolbar #addCard{margin-left:auto}
+
+.fab-menu{position:fixed;right:24px;bottom:100px;display:flex;flex-direction:column;gap:6px;min-width:200px;padding:8px 0;border-radius:12px;background:#fff;box-shadow:var(--shadow2);border:1px solid var(--border);z-index:65}
+.fab-menu[hidden]{display:none}
+.fab-menu button{padding:10px 16px;text-align:left;background:none;border:none;font:inherit;color:var(--ink);cursor:pointer;transition:background var(--dur) var(--ease),color var(--dur) var(--ease);display:flex;align-items:center;gap:10px}
+.fab-menu button:hover,.fab-menu button:focus{background:#eef4ff;color:var(--primary);outline:none}
 
 /* Activity cards (compact header) */
 .card.activity{background:#f7f8fa;border-color:#e6e9f2}
@@ -381,24 +381,12 @@ body.avatar-overlay-open{overflow:hidden}
       </button>
     </div>
     <div class="toolbar">
-      <div id="dmActions" class="dm-actions" hidden aria-hidden="true">
-        <button id="dmNewEntryBtn" class="btn small" type="button" aria-expanded="false" aria-haspopup="true">
-          <span class="btn-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
-          </span>
-          New entry
-        </button>
-        <div id="dmNewEntryMenu" class="dm-menu" role="menu" hidden>
-          <button type="button" class="dm-menu-item" role="menuitem" data-dm-action="session">New session</button>
-          <button type="button" class="dm-menu-item" role="menuitem" data-dm-action="allocation">New allocation</button>
-        </div>
-      </div>
       <div class="search">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="2"/></svg>
         <input id="q" placeholder="Search adventures"/>
       </div>
       <button id="activityToggle" class="btn small" type="button" aria-pressed="false">Hide activities</button>
-      <button id="addCard" class="icon-btn" title="Add new adventure" aria-label="Add new adventure">
+      <button id="addCard" title="Add new entry" aria-label="Add new entry" type="button" aria-haspopup="true" aria-expanded="false">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
       </button>
     </div>
@@ -447,6 +435,8 @@ body.avatar-overlay-open{overflow:hidden}
   <section id="grid" class="grid cols"></section>
   <div id="empty" class="empty" style="display:none;">No adventures match your filters.</div>
 </div>
+
+<div id="addCardMenu" class="fab-menu" role="menu" hidden aria-hidden="true"></div>
 
 <div id="dmItemsModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="dmItemsTitle">
   <div class="modal-card dm-items-card">
@@ -561,6 +551,7 @@ const emptyEl  = document.getElementById('empty');
 const badgesEl = document.getElementById('charBadges');
 const metaEl   = document.getElementById('charMeta');
 const addCardBtn = document.getElementById('addCard');
+const addCardMenu = document.getElementById('addCardMenu');
 const activityToggleBtn = document.getElementById('activityToggle');
 const headerQuick = document.getElementById('headerQuick');
 const dmSummaryBar = document.getElementById('dmSummaryBar');
@@ -571,9 +562,6 @@ const dmItemsBtnEl = document.getElementById('dmItemsBtn');
 const dmItemsModal = document.getElementById('dmItemsModal');
 const dmItemsListEl = document.getElementById('dmItemsList');
 const dmItemsCloseBtn = document.getElementById('dmItemsClose');
-const dmActionsWrap = document.getElementById('dmActions');
-const dmNewEntryBtn = document.getElementById('dmNewEntryBtn');
-const dmNewEntryMenu = document.getElementById('dmNewEntryMenu');
 const cardOverlay=document.getElementById('cardOverlay');
 const avatarOverlay=document.getElementById('avatarOverlay');
 const avatarPreview=avatarOverlay?avatarOverlay.querySelector('.avatar-preview'):null;
@@ -872,8 +860,72 @@ function refreshModalState(){
   else{ document.body.classList.remove('modal-open'); }
 }
 
+function closeAddMenu(){
+  if(addCardMenu){
+    addCardMenu.hidden=true;
+    addCardMenu.setAttribute('aria-hidden','true');
+    addCardMenu.innerHTML='';
+  }
+  if(addCardBtn){
+    addCardBtn.setAttribute('aria-expanded','false');
+  }
+}
+
+function dispatchDmNewEntry(type){
+  if(!type) return;
+  window.dispatchEvent(new CustomEvent('dm:new-entry',{detail:{type}}));
+}
+
+function buildAddMenuOptions(){
+  if(!charSel) return [];
+  const key=charSel.value;
+  if(isDmLogKey(key)){
+    if(!hasDmLogData()) return [];
+    return [
+      {label:'New session', action:()=>dispatchDmNewEntry('session')},
+      {label:'New allocation', action:()=>dispatchDmNewEntry('allocation')}
+    ];
+  }
+  if(!isValidSheetKey(key)) return [];
+  return [
+    {label:'New adventure', action:()=>createCharacterNewEntry('adventure')},
+    {label:'Downtime activity', action:()=>createCharacterNewEntry('Downtime Activity')}
+  ];
+}
+
+function openAddMenu(){
+  if(!addCardMenu||!addCardBtn) return;
+  const options=buildAddMenuOptions();
+  if(!options.length){
+    closeAddMenu();
+    return;
+  }
+  addCardMenu.innerHTML='';
+  options.forEach(option=>{
+    const btn=document.createElement('button');
+    btn.type='button';
+    btn.className='fab-menu-item';
+    btn.textContent=option.label;
+    btn.setAttribute('role','menuitem');
+    btn.addEventListener('click',()=>{
+      closeAddMenu();
+      option.action();
+    });
+    addCardMenu.appendChild(btn);
+  });
+  addCardMenu.hidden=false;
+  addCardMenu.setAttribute('aria-hidden','false');
+  addCardBtn.setAttribute('aria-expanded','true');
+  const first=addCardMenu.querySelector('button');
+  if(first){
+    try{ first.focus({preventScroll:true}); }
+    catch(err){ first.focus(); }
+  }
+}
+
 function openCardOverlay(card){
   if(!cardOverlay || !card) return;
+  closeAddMenu();
   cardOverlay.innerHTML='';
   cardOverlay.appendChild(card);
   cardOverlay.classList.add('open');
@@ -889,6 +941,39 @@ function closeCardOverlay(){
   overlayCard=null;
   cardOverlay.innerHTML='';
   refreshModalState();
+}
+
+function createCharacterNewEntry(kind){
+  if(!DATA || !DATA.characters || !charSel) return;
+  const key=charSel.value;
+  if(!isValidSheetKey(key) || !DATA.characters[key]) return;
+  const normalized=kind==='Downtime Activity'?'Downtime Activity':'adventure';
+  const isActivity=normalized!=='adventure';
+  const today=new Date().toISOString().slice(0,10);
+  const template={
+    date:today,
+    title:isActivity?'New Downtime Activity':'New Adventure',
+    code:'',
+    dm:'',
+    gp_plus:0,
+    gp_minus:0,
+    dtd_plus:0,
+    dtd_minus:0,
+    level_plus:0,
+    perm_items:[],
+    lost_perm_item:'',
+    consumable_items:[],
+    notes:'',
+    kind:normalized,
+    traded_item:'',
+    __openEdit:true,
+    __isNew:true,
+    __charKey:key,
+    __lockedKind:normalized
+  };
+  const card=makeCard(template,-1);
+  card.classList.add('overlay-card');
+  openCardOverlay(card);
 }
 
 function loadDataDraft(){
@@ -1824,6 +1909,7 @@ function updateDmSummaryBar(){
 }
 function openDmItemsModal(){
   if(!dmItemsModal) return;
+  closeAddMenu();
   updateDmSummaryBar();
   dmItemsModal.classList.add('open');
   refreshModalState();
@@ -1844,19 +1930,6 @@ function closeDmItemsModal(){
     dmItemsBtnEl.setAttribute('aria-expanded','false');
   }
 }
-function openDmEntryMenu(){
-  if(!dmNewEntryMenu||!dmNewEntryBtn) return;
-  dmNewEntryMenu.hidden=false;
-  dmNewEntryBtn.setAttribute('aria-expanded','true');
-}
-function closeDmEntryMenu(){
-  if(dmNewEntryMenu){
-    dmNewEntryMenu.hidden=true;
-  }
-  if(dmNewEntryBtn){
-    dmNewEntryBtn.setAttribute('aria-expanded','false');
-  }
-}
 function setDmHeader(){
   if(avatarEl){
     resetAvatar();
@@ -1873,6 +1946,7 @@ function setDmHeader(){
   }
 }
 function updateUiForSelection(key){
+  closeAddMenu();
   const isDm=isDmLogKey(key);
   if(headerQuick){
     headerQuick.style.display=isDm?'none':'';
@@ -1883,15 +1957,7 @@ function updateUiForSelection(key){
     dmSummaryBar.hidden=!showSummary;
     dmSummaryBar.setAttribute('aria-hidden', showSummary?'false':'true');
   }
-  if(dmActionsWrap){
-    const showActions=isDm && hasDmLogData();
-    dmActionsWrap.hidden=!showActions;
-    dmActionsWrap.setAttribute('aria-hidden', showActions?'false':'true');
-    if(!showActions){
-      closeDmEntryMenu();
-      closeDmItemsPopover();
-    }
-  }else if(!isDm){
+  if(!isDm){
     closeDmItemsPopover();
   }
   if(activityToggleBtn){
@@ -1899,8 +1965,12 @@ function updateUiForSelection(key){
     activityToggleBtn.setAttribute('aria-hidden', isDm?'true':'false');
   }
   if(addCardBtn){
-    addCardBtn.style.display=isDm?'none':'';
-    addCardBtn.setAttribute('aria-hidden', isDm?'true':'false');
+    const showButton=!isDm || hasDmLogData();
+    addCardBtn.style.display=showButton?'':'';
+    addCardBtn.setAttribute('aria-hidden', showButton?'false':'true');
+    if(!showButton){
+      closeAddMenu();
+    }
   }
   if(qEl){
     const placeholder=isDm?'Search DM log entries':(defaultSearchPlaceholder||'');
@@ -1911,6 +1981,16 @@ function updateUiForSelection(key){
       qEl.removeAttribute('aria-label');
     }
   }
+  updateAddButtonContext(isDm);
+}
+
+function updateAddButtonContext(isDm){
+  if(!addCardBtn) return;
+  const description=isDm?'Add a new DM session or reward allocation':'Add a new adventure or downtime activity';
+  addCardBtn.title=description;
+  addCardBtn.setAttribute('aria-label', description);
+  const expanded=(addCardMenu && !addCardMenu.hidden)?'true':'false';
+  addCardBtn.setAttribute('aria-expanded', expanded);
 }
 function renderDmLog(){
   if(!grid) return;
@@ -2929,6 +3009,8 @@ function makeCard(a,idx){
   const act=isActivityEntry(a); const {gp,dtd}=netVals(a);
   const card=document.createElement('article'); card.className='card'+(act?' activity':''); card.dataset.idx=String(idx);
   card.__dataRef=a;
+  const lockedKind=(a && a.__lockedKind)?String(a.__lockedKind):'';
+  const hasLockedKind=!!lockedKind;
 
   const hd=document.createElement('div'); hd.className='card-hd';
   const main=document.createElement('div');
@@ -3168,6 +3250,14 @@ function makeCard(a,idx){
     return select;
   }
   controls.kind=addField('Kind', makeKindSelect());
+  if(hasLockedKind){
+    controls.kind.value=lockedKind;
+    controls.kind.disabled=true;
+    const kindFieldEl=controls.kind.closest('.field');
+    if(kindFieldEl){
+      kindFieldEl.style.display='none';
+    }
+  }
   controls.traded_item=addField('Item traded away', makeInput('text'));
 
   const gpRowForm=document.createElement('div'); gpRowForm.className='kv2';
@@ -3422,9 +3512,10 @@ function makeCard(a,idx){
   view.appendChild(actions);
 
   function populate(editing=false){
-    const kindRaw=(a.kind||'').toString();
+    const kindRaw=hasLockedKind?lockedKind:(a.kind||'').toString();
     const kindVal=kindRaw && kindRaw.toLowerCase()!=='adventure'?'Downtime Activity':'adventure';
     controls.kind.value=kindVal;
+    controls.kind.disabled=hasLockedKind;
     const isActivityMode=(controls.kind.value||'adventure')!=='adventure';
 
     const titleRaw=a.title||'';
@@ -3448,7 +3539,8 @@ function makeCard(a,idx){
 
     const kindLabel=(controls.kind.value||'adventure')==='adventure'?'Adventure':'Downtime Activity';
     kindField.__display.textContent=kindLabel;
-    kindField.style.display=editing?'':'none';
+    const showKindField=editing && !hasLockedKind;
+    kindField.style.display=showKindField?'':'none';
 
     const dmRaw=a.dm||'';
     controls.dm.value=dmRaw;
@@ -3630,6 +3722,9 @@ async function saveCardChanges(card){
     }
     delete data.__isNew;
     delete data.__charKey;
+  }
+  if(Object.prototype.hasOwnProperty.call(data,'__lockedKind')){
+    delete data.__lockedKind;
   }
   markDirty();
   exitEditMode(card);
@@ -3919,24 +4014,6 @@ function filterAndRender(){
 /* --- events --- */
 qEl.addEventListener('input',filterAndRender);
 charSel.addEventListener('change',filterAndRender);
-if(dmNewEntryBtn){
-  dmNewEntryBtn.addEventListener('click',()=>{
-    if(dmNewEntryMenu && !dmNewEntryMenu.hidden){
-      closeDmEntryMenu();
-    }else{
-      openDmEntryMenu();
-    }
-  });
-}
-if(dmNewEntryMenu){
-  dmNewEntryMenu.addEventListener('click',(event)=>{
-    const actionBtn=event.target.closest('.dm-menu-item');
-    if(!actionBtn) return;
-    const action=actionBtn.getAttribute('data-dm-action')||'';
-    closeDmEntryMenu();
-    window.dispatchEvent(new CustomEvent('dm:new-entry',{detail:{type:action}}));
-  });
-}
 if(dmItemsBtnEl){
   dmItemsBtnEl.addEventListener('click',()=>{
     const isOpen=dmItemsModal && dmItemsModal.classList.contains('open');
@@ -3960,17 +4037,19 @@ if(dmItemsModal){
   });
 }
 document.addEventListener('click',(event)=>{
-  if(dmNewEntryMenu && !dmNewEntryMenu.hidden){
-    if(!dmNewEntryMenu.contains(event.target) && !(dmNewEntryBtn && dmNewEntryBtn.contains(event.target))){
-      closeDmEntryMenu();
+  if(addCardMenu && !addCardMenu.hidden){
+    const withinMenu=addCardMenu.contains(event.target);
+    const withinButton=addCardBtn && addCardBtn.contains(event.target);
+    if(!withinMenu && !withinButton){
+      closeAddMenu();
     }
   }
 });
 document.addEventListener('keydown',(event)=>{
   if(event.key==='Escape'){
     let handled=false;
-    if(dmNewEntryMenu && !dmNewEntryMenu.hidden){
-      closeDmEntryMenu();
+    if(addCardMenu && !addCardMenu.hidden){
+      closeAddMenu();
       handled=true;
     }
     if(dmItemsModal && dmItemsModal.classList.contains('open')){
@@ -4082,33 +4161,11 @@ if(downloadBtn){
 }
 if(addCardBtn){
   addCardBtn.addEventListener('click',()=>{
-    const key=charSel.value;
-    const ch=DATA.characters[key];
-    if(!ch) return;
-    const today=new Date().toISOString().slice(0,10);
-    const template={
-      date:today,
-      title:'New Adventure',
-      code:'',
-      dm:'',
-      gp_plus:0,
-      gp_minus:0,
-      dtd_plus:0,
-      dtd_minus:0,
-      level_plus:0,
-      perm_items:[],
-      lost_perm_item:'',
-      consumable_items:[],
-      notes:'',
-      kind:'adventure',
-      traded_item:'',
-      __openEdit:true,
-      __isNew:true,
-      __charKey:key
-    };
-    const card=makeCard(template,-1);
-    card.classList.add('overlay-card');
-    openCardOverlay(card);
+    if(addCardMenu && !addCardMenu.hidden){
+      closeAddMenu();
+    }else{
+      openAddMenu();
+    }
   });
 }
 </script>


### PR DESCRIPTION
## Summary
- replace the header new-entry button with the existing floating action button and give it a context-aware menu for characters and the DM log
- preselect the entry type for new character entries created through the menu and hide the kind selector on those forms

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e198b027dc8321927f979d85325c0e