### PR TITLE
Fix DM modal close call to allow character data boot

### DIFF
--- a/index.html
+++ b/index.html
@@ -1958,7 +1958,7 @@ function updateUiForSelection(key){
     dmSummaryBar.setAttribute('aria-hidden', showSummary?'false':'true');
   }
   if(!isDm){
-    closeDmItemsPopover();
+    closeDmItemsModal();
   }
   if(activityToggleBtn){
     activityToggleBtn.style.display=isDm?'none':'';


### PR DESCRIPTION
## Summary
- ensure the DM log modal closing helper uses the existing closeDmItemsModal function
- prevent runtime errors that blocked the character data grid from rendering

## Testing
- browser_container.run_playwright_script to load index.html and verify the grid renders

------
https://chatgpt.com/codex/tasks/task_e_68e1ae70e9288321aac512c1cd62ba3b