### PR TITLE
Remove deployment notice banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@ h1{margin:0;font-size:28px;line-height:1.05;font-weight:800;letter-spacing:-0.01
 
 /* Toolbar */
 .toolbar{margin-top:10px;display:flex;gap:10px;flex-wrap:wrap}
-.deployment-notice{margin-top:12px;padding:10px 12px;border-radius:12px;background:rgba(26,115,232,.12);color:#0b3f88;font-weight:600;font-size:13px;display:flex;align-items:center;gap:8px}
 .select,.btn,.search input{border:1px solid var(--border);background:#fff;border-radius:12px;padding:10px 12px;font-weight:600;box-shadow:var(--shadow1)}
 .btn{cursor:pointer;transition:transform var(--dur) var(--ease),box-shadow var(--dur) var(--ease)}
 .btn:hover{transform:translateY(-1px);box-shadow:var(--shadow2)}
@@ -398,9 +397,6 @@ body.avatar-overlay-open{overflow:hidden}
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
       </button>
     </div>
-    <div id="deploymentNotice" class="deployment-notice" role="status" aria-live="polite" hidden>
-      Waiting for deployment…
-    </div>
     <div class="header-quick" id="headerQuick">
       <div class="inventory-buttons">
         <button id="magicItemsBtn" class="inventory-link" type="button" title="View permanent magic items" aria-label="View permanent magic items">
@@ -556,7 +552,6 @@ let DATA = window.DATA || null;
 const charSel  = document.getElementById('charSel');
 const avatarEl = document.getElementById('charAvatar');
 const downloadBtn = document.getElementById('downloadData');
-const deploymentNotice = document.getElementById('deploymentNotice');
 const qEl      = document.getElementById('q');
 const grid     = document.getElementById('grid');
 const emptyEl  = document.getElementById('empty');
@@ -580,7 +575,6 @@ const avatarPreview=avatarOverlay?avatarOverlay.querySelector('.avatar-preview')
 const avatarPreviewImage=avatarOverlay?avatarOverlay.querySelector('.avatar-preview-image'):null;
 const dataScriptEl=document.getElementById('dataScript');
 const DATA_VERSION_KEY=window.AL_DATA_VERSION_KEY||'al_logs_data_version';
-const DEFAULT_DEPLOYMENT_NOTICE=(deploymentNotice && deploymentNotice.textContent && deploymentNotice.textContent.trim())||'Waiting for deployment…';
 let dataVersion=(dataScriptEl&&dataScriptEl.getAttribute('data-version'))||window.AL_DATA_VERSION||'';
 window.AL_DATA_VERSION=dataVersion;
 let dataCacheBust=(dataScriptEl&&dataScriptEl.getAttribute('data-cache-bust'))||window.AL_DATA_CACHE_BUST||'';
@@ -862,19 +856,6 @@ function setSaveResult(state){
   updateSaveButtonState();
 }
 
-function showDeploymentNotice(message=DEFAULT_DEPLOYMENT_NOTICE){
-  if(!deploymentNotice) return;
-  const text=(message==null?DEFAULT_DEPLOYMENT_NOTICE:String(message));
-  deploymentNotice.hidden=false;
-  deploymentNotice.textContent=text;
-}
-
-function hideDeploymentNotice(){
-  if(!deploymentNotice) return;
-  deploymentNotice.hidden=true;
-  deploymentNotice.textContent=DEFAULT_DEPLOYMENT_NOTICE;
-}
-
 function anyModalOpen(){
   return (invModal && invModal.classList.contains('open'))
     || (consModal && consModal.classList.contains('open'))
@@ -1058,16 +1039,16 @@ if(typeof window!=='undefined'){
   window.addEventListener('pagehide',discardDraftBeforeNavigation);
   window.addEventListener('unload',discardDraftBeforeNavigation);
 }
-function applyDraftIfAvailable(){
-  if(draftStateApplied) return;
-  draftStateApplied=true;
+function applyDraftIfAvailable({force=false}={}){
+  if(draftStateApplied && !force) return false;
   let draft=null;
   try{
     draft=loadDataDraft();
   }catch(err){
     draft=null;
   }
-  if(!draft||!draft.data||!draft.data.characters) return;
+  if(!draft||!draft.data||!draft.data.characters) return false;
+  draftStateApplied=true;
   window.DATA=draft.data;
   DATA=window.DATA;
   if(draft.version){
@@ -1079,7 +1060,21 @@ function applyDraftIfAvailable(){
   clearTimeout(saveFeedbackTimeout);
   hasLocalDraft=true;
   updateSaveButtonState();
-  showDeploymentNotice();
+  return true;
+}
+
+function reapplyLocalDraftAndRefresh(){
+  const applied=applyDraftIfAvailable({force:true});
+  if(applied){
+    DATA=window.DATA||DATA;
+    if(__appInitialized){
+      refreshAllDerivedData();
+      rebuildCharacterOptions({preserveSelection:true});
+      filterAndRender();
+      scheduleAvatarPreload();
+    }
+  }
+  return applied;
 }
 
 function markDirty(){
@@ -1093,7 +1088,6 @@ function clearDirty(){
   lastSaveResult=null;
   clearTimeout(saveFeedbackTimeout);
   clearDataDraft();
-  hideDeploymentNotice();
   updateSaveButtonState();
 }
 
@@ -1178,7 +1172,7 @@ async function saveDataJs(options={}){
       }
       if(hadPendingChanges || hasLocalDraft || shouldPersistDraft){
         pendingChanges=true;
-        showDeploymentNotice();
+        reapplyLocalDraftAndRefresh();
         setSaveResult(null);
       }
     }
@@ -4522,10 +4516,17 @@ function ensureAppInitialized(){
 }
 
 function tryInitApp(){
-  applyDraftIfAvailable();
+  const usedDraft=applyDraftIfAvailable({force:pendingChanges || hasLocalDraft});
   if(window.DATA && window.DATA.characters){
+    const wasInitialized=__appInitialized;
     DATA=window.DATA;
     ensureAppInitialized();
+    if(usedDraft && wasInitialized){
+      refreshAllDerivedData();
+      rebuildCharacterOptions({preserveSelection:true});
+      filterAndRender();
+      scheduleAvatarPreload();
+    }
     return __appInitialized;
   }
   return false;


### PR DESCRIPTION
## Summary
- remove the deployment notice markup and styling from the header so no alert banner renders
- add a helper to reapply local draft data when needed and reuse it after failed save attempts

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1fff5fba08321b36f096c95ad9b91