### PR TITLE
Add local save/load fallbacks and improve inventory parsing

### DIFF
--- a/api/data-proxy.js
+++ b/api/data-proxy.js
@@ -1,4 +1,7 @@
-export const config = { runtime: 'edge' };
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export const config = { runtime: 'nodejs' };
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -74,6 +77,25 @@ const determineBranch = async ({ repo, headers }) => {
   };
 };
 
+
+const readLocalDataFile = async (inputPath) => {
+  const cwd = process.cwd();
+  const targetPath = path.resolve(cwd, String(inputPath || DEFAULT_DATA_PATH));
+  const relativeTarget = path.relative(cwd, targetPath);
+  if (relativeTarget.startsWith('..') || path.isAbsolute(relativeTarget)) {
+    return { error: { status: 400, message: 'Resolved data path escapes repository root.' } };
+  }
+  try {
+    const body = await fs.readFile(targetPath, 'utf8');
+    return { body };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return { error: { status: 404, message: `Could not locate ${inputPath}.` } };
+    }
+    return { error: { status: 500, message: 'Failed to read local data file.', details: String(error && error.message ? error.message : error) } };
+  }
+};
+
 const resolveCommitShaForRef = async ({ repo, ref, headers }) => {
   const normalizedRef = String(ref || '').trim();
   if (!normalizedRef) {
@@ -135,19 +157,7 @@ export default async function handler(req) {
 
   try {
     const repo = process.env.GH_REPO;
-    if (!repo) {
-      return respond({ error: 'GH_REPO not set' }, { status: 500 });
-    }
-
     const token = process.env.GH_TOKEN;
-    if (!token) {
-      return respond({ error: 'GH_TOKEN not set' }, { status: 500 });
-    }
-
-    const authHeaders = {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github.v3.raw'
-    };
 
     const url = new URL(req.url);
     const params = url.searchParams;
@@ -158,6 +168,30 @@ export default async function handler(req) {
     if (!encodedPath) {
       return respond({ error: 'Invalid or empty data path provided.' }, { status: 400 });
     }
+
+    if (!repo || !token) {
+      const localResult = await readLocalDataFile(pathParam);
+      if (localResult.error) {
+        return respond({ error: localResult.error.message, details: localResult.error.details || null }, {
+          status: localResult.error.status || 500
+        });
+      }
+      return respond(localResult.body, {
+        json: false,
+        headers: {
+          'content-type': 'application/javascript; charset=utf-8',
+          'cache-control': cacheBustToken ? 'no-store, max-age=0' : 'public, max-age=5',
+          'x-data-path': pathParam,
+          'x-data-ref': 'local-file',
+          'x-data-ref-source': 'filesystem'
+        }
+      });
+    }
+
+    const authHeaders = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.v3.raw'
+    };
 
     const requestedRef = (params.get('ref') || params.get('v') || '').trim();
     let refToUse = requestedRef;

--- a/api/save-data.js
+++ b/api/save-data.js
@@ -1,5 +1,7 @@
-// Vercel Edge Function – commits data.js to your repo via GitHub API
-export const config = { runtime: 'edge' };
+import { promises as fs } from 'node:fs';
+import pathModule from 'node:path';
+
+export const config = { runtime: 'nodejs' };
 
 const corsHeaders = {
   'access-control-allow-origin': '*',
@@ -57,9 +59,25 @@ export default async function handler(req) {
     }
 
     const repo = process.env.GH_REPO;   // e.g. "Lebowskigrande/AL-logs"
-    if (!repo)  return respond({ error: 'GH_REPO not set' },  { status: 500 });
     const token = process.env.GH_TOKEN; // fine-grained PAT or GitHub App token
-    if (!token) return respond({ error: 'GH_TOKEN not set' }, { status: 500 });
+
+    if (!repo || !token) {
+      const cwd = process.cwd();
+      const targetPath = pathModule.resolve(cwd, String(path || DEFAULT_DATA_PATH));
+      const normalizedRoot = `${pathModuleResolveWithSlash(cwd)}`;
+      const normalizedTarget = pathModuleResolveWithSlash(targetPath);
+      if (!normalizedTarget.startsWith(normalizedRoot)) {
+        return respond({ error: 'Resolved save path escapes repository root.' }, { status: 400 });
+      }
+      await fs.mkdir(pathModule.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, dataJs, 'utf8');
+      return respond({
+        ok: true,
+        mode: 'local-file',
+        path: String(path || DEFAULT_DATA_PATH),
+        savedAt: new Date().toISOString()
+      });
+    }
 
     // Optional: simple shared secret for client -> function
     const clientKey = req.headers.get('x-save-key');
@@ -107,4 +125,9 @@ export default async function handler(req) {
   } catch (e) {
     return respond({ error: String(e) }, { status: 500 });
   }
+}
+
+function pathModuleResolveWithSlash(value) {
+  const resolved = pathModule.resolve(String(value || ''));
+  return resolved.endsWith(pathModule.sep) ? resolved : `${resolved}${pathModule.sep}`;
 }

--- a/index.html
+++ b/index.html
@@ -6046,7 +6046,16 @@
     let saveQueueTail = Promise.resolve();
     const pendingDerivedUpdates = new Set();
     const inventoryStateAutoSaveQueue = new Set();
-    const SAVE_ENDPOINT = (typeof window !== 'undefined' && window.AL_SAVE_ENDPOINT) || 'https://al-logs.vercel.app/api/save-data';
+    const SAVE_ENDPOINT = (() => {
+      if (typeof window === 'undefined') return '/api/save-data';
+      if (window.AL_SAVE_ENDPOINT) return window.AL_SAVE_ENDPOINT;
+      const host = String(window.location && window.location.hostname || '').toLowerCase();
+      const protocol = String(window.location && window.location.protocol || '').toLowerCase();
+      if (host === 'localhost' || host === '127.0.0.1' || protocol === 'file:') {
+        return '/api/save-data';
+      }
+      return 'https://al-logs.vercel.app/api/save-data';
+    })();
     const SAVE_HEADERS = (typeof window !== 'undefined' && window.AL_SAVE_HEADERS) || null;
     const STORAGE_KEYS = {
       showActivities: 'al_logs_show_activities',
@@ -11559,18 +11568,23 @@
       }
       const text = String(raw || '').replace(/\r\n?/g, '\n').trim();
       if (!text) return [];
-      if (text.includes('\n')) {
-        return text.split('\n').map(normItemName).filter(Boolean);
-      }
-      if (text.includes(';')) {
-        return text.split(';').map(normItemName).filter(Boolean);
-      }
-      if (text.includes('•')) {
-        return text.split('•').map(normItemName).filter(Boolean);
-      }
-      return [normItemName(text)];
+      const separators = /\n|;|•|(?<!\d),(?!\d)/g;
+      const tokens = text.split(separators).map(normItemName).filter(Boolean);
+      return tokens.length ? tokens : [normItemName(text)];
     }
-    function parseAcquisitionName(s) { const t = String(s || '').trim(); const m = t.match(/^\((.*)\)$/); return m ? { name: m[1].trim(), acquired: false } : { name: t, acquired: true }; }
+    function parseAcquisitionName(s) {
+      const t = String(s || '').trim();
+      if (!t) return { name: '', acquired: true };
+      const wrappedRemoval = t.match(/^\((.*)\)$/);
+      if (wrappedRemoval) {
+        return { name: wrappedRemoval[1].trim(), acquired: false };
+      }
+      const prefixedRemoval = t.match(/^(?:-|lost\s*:|remove\s*:|traded\s*(?:away)?\s*:?)\s*(.+)$/i);
+      if (prefixedRemoval) {
+        return { name: prefixedRemoval[1].trim(), acquired: false };
+      }
+      return { name: t, acquired: true };
+    }
 
     function buildAdventureInventoryOperation(adv) {
       const operation = { adds: [], removes: [] };


### PR DESCRIPTION
### Motivation
- The dashboard relied on GitHub API edge functions for loading and saving `data/data.js`, which made local clones fragile and prevented reliable saves when `GH_REPO`/`GH_TOKEN` were not configured.
- Item acquisition/loss parsing was brittle and caused inventory chronology mismatches for common formats (commas, prefixed removal markers, etc.).

### Description
- Switched `api/save-data.js` and `api/data-proxy.js` from edge runtime to Node runtime and added local-file fallbacks that read/write `data/data.js` when GitHub env vars are missing, with path traversal protections.
- In `api/save-data.js` the handler now writes the incoming `dataJs` to the configured path on disk when `GH_REPO`/`GH_TOKEN` are not set and returns a JSON success payload indicating `mode: 'local-file'`.
- In `api/data-proxy.js` the handler now attempts to read the local `data/data.js` when GitHub credentials are absent and returns the file contents with appropriate headers and error handling.
- Updated the client save endpoint selection in `index.html` so local/file-based runs default to `/api/save-data` (localhost/file: use the local API) and hardened inventory parsing by improving `parseLostItemList` to handle newline/semicolon/bullet/comma separators and updating `parseAcquisitionName` to recognize wrapped removals and common removal prefixes like `lost:` / `remove:` / `traded away:`.

### Testing
- Ran `node --check api/save-data.js` and the file passed syntax checks (success).
- Ran `node --check api/data-proxy.js` and the file passed syntax checks (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09293f8708321b41249d658a6481b)